### PR TITLE
chore: update release workflow to add tauri

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,8 @@ jobs:
 
       - name: Import Apple Developer Certificate
         # Prevents keychain from locking automatically for 3600 seconds.
-        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main' && !inputs.dry-run
+        # temporary commenting this->> if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main' && !inputs.dry-run
+        if: matrix.os == 'macos-latest'  # MacOS Only <<-temporary adding this
         env:
           APPLE_CERTIFICATE: ${{ secrets.MACOS_CSC_LINK }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,13 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
-
 defaults:
   run:
     shell: 'bash'
 
+env:
+  VITE_AWS_S3_BUCKET_PUBLIC_URL: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
+  PROJECT_PATH: src-tauri
 
 jobs:
   draft_release:
@@ -71,17 +73,26 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: swatinem/rust-cache@v2
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
 
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          cache-targets: true
+          cache-provider: github
+
       - uses: actions/setup-node@v4
         with:
+          node-version: lts/*
           cache: 'npm'
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - run: npm ci
         env:
@@ -96,7 +107,6 @@ jobs:
           # Sentry AUTH Token
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          VITE_AWS_S3_BUCKET_PUBLIC_URL: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
 
       - name: Generate Release Version
         id: version
@@ -113,18 +123,19 @@ jobs:
 
       # Download 'SSLcom/esigner-codesign' to a folder called 'esigner-codesign' in the root of the project
       - name: Checkout esigner-codesign repository (Windows)
-        if: ${{github.ref == 'refs/heads/main' && matrix.os == 'windows-latest' && !inputs.dry-run}}
+        if: matrix.os == 'windows-latest' && github.ref == 'refs/heads/main' && !inputs.dry-run
         uses: actions/checkout@v3
         with:
           repository: 'SSLcom/esigner-codesign'
           path: esigner-codesign
 
-      - name: import Apple Developer Certificate
+      - name: Import Apple Developer Certificate
         # Prevents keychain from locking automatically for 3600 seconds.
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main' && !inputs.dry-run
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.MACOS_CSC_LINK }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
         run: |
           echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
           security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
@@ -135,24 +146,24 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
           security find-identity -v -p codesigning build.keychain
   
-      - name: verify certificate
+      - name: Verify certificate
+        if: matrix.os == 'macos-latest'  # MacOS Only
         run: |
           CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")
           CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
           echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
           echo "Certificate imported."
-  
+
       - name: Build MacOS
-        if: matrix.os == 'macos-latest'  # MacOS Only 
+        if: matrix.os == 'macos-latest'  # MacOS Only
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_PWD }}
           APPLE_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE: ${{ secrets.MACOS_CSC_LINK }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
-
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           releaseName: "App v__VERSION__"
@@ -160,6 +171,7 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ secrets.args }}
+          projectPath: ${{ env.PROJECT_PATH }}
 
       - name: Build Windows
         if: matrix.os == 'windows-latest'  # Windows Only 
@@ -173,6 +185,6 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ secrets.args }}
+          projectPath: ${{ env.PROJECT_PATH }}
 
           # todo publish      - name: Compile artifacts ${{ inputs.dry-run && '' || 'and upload them to github release' }}
-

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
-name = "Decentraland Launcher"
-# should be synchronized youwith tauri.conf.json !!!
+name = "Decentraland-Launcher"
+# should be synchronized with tauri.conf.json !!!
 version = "1.0.1"
 
 description = "Decentraland Launcher App"
 authors = ["Decentraland"]
 edition = "2021"
 default-run = "app"
+
+[[bin]]
+name = "app"
+path = "src/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Decentraland Launcher",
+  "productName": "Decentraland-Launcher",
   "mainBinaryName": "dcl_launcher",
   "version": "1.0.1",
   "identifier": "com.decentraland.launcherlite",


### PR DESCRIPTION
- set vite s3 public url and project path as global env vars
- improved rust caching and setup steps order
- updated certificate import with correct secret names
- passed projectPath to tauri build steps
- renamed app to decentraland-launcher in config files
- added explicit binary entry in cargo.toml