### PR TITLE
feat: Add download progress event.

### DIFF
--- a/core/src/analytics.rs
+++ b/core/src/analytics.rs
@@ -15,8 +15,7 @@ use crate::{config, utils::{ app_version, get_os_name}};
 
 pub struct CreateArgs {
     write_key: String, 
-    anonymous_id: String, 
-    user_id: String,
+    anonymous_id: String,
     os: String, 
     launcher_version: String,
 }
@@ -34,8 +33,7 @@ impl Analytics {
         let args: Option<CreateArgs> = match write_key {
             Some(segment_key) => {
                 info!("SEGMENT_API_KEY is set successfully from environment variable, segment is available");                
-                let anonymous_id = uuid::Uuid::new_v4().to_string();
-                let user_id = config::user_id().unwrap_or_else(|e| {
+                let anonymous_id = config::user_id().unwrap_or_else(|e| {
                     error!("Cannot get user id from config, fallback is used: {}", e);
                     "none".to_owned()
                 });
@@ -44,7 +42,6 @@ impl Analytics {
                 let args = CreateArgs {
                     write_key: segment_key.to_owned(),
                     anonymous_id,
-                    user_id,
                     os,
                     launcher_version,
                 };
@@ -61,7 +58,7 @@ impl Analytics {
     pub fn new(args: Option<CreateArgs>) -> Self {
         match args {
             Some(a) => {
-                let client = AnalyticsClient::new(a.write_key, a.anonymous_id, a.user_id, a.os, a.launcher_version);
+                let client = AnalyticsClient::new(a.write_key, a.anonymous_id, a.os, a.launcher_version);
                 Analytics::Client(client)
             },
             None => {

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -9,11 +9,10 @@ use anyhow::Result;
 use super::event::Event;
 use super::session::SessionId;
 
-const APP_ID: &str = "decentraland-launcher";
+const APP_ID: &str = "decentraland-launcher-rust";
 
 pub struct AnalyticsClient {
     anonymous_id: String,
-    user_id: String,
     os: String,
     launcher_version: String,
     session_id: SessionId,
@@ -22,7 +21,7 @@ pub struct AnalyticsClient {
 
 impl AnalyticsClient {
 
-    pub fn new(write_key: String, anonymous_id: String, user_id: String, os: String, launcher_version: String) -> Self {
+    pub fn new(write_key: String, anonymous_id: String, os: String, launcher_version: String) -> Self {
         let client = HttpClient::default();
         let context = json!({"direct": true}); 
         let batcher = Batcher::new(Some(context));
@@ -31,7 +30,6 @@ impl AnalyticsClient {
 
         AnalyticsClient {
             anonymous_id,
-            user_id,
             os,
             session_id,
             launcher_version,
@@ -46,7 +44,6 @@ impl AnalyticsClient {
         properties["appId"] = Value::from_str(APP_ID)?;
 
         let user = User::Both {
-            user_id: self.user_id.clone(),
             anonymous_id: self.anonymous_id.clone()
         };
 

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -43,7 +43,7 @@ impl AnalyticsClient {
         properties["sessionId"] = Value::from_str(self.session_id.value())?;
         properties["appId"] = Value::from_str(APP_ID)?;
 
-        let user = User::Both {
+        let user = User::AnonymousId {
             anonymous_id: self.anonymous_id.clone()
         };
 

--- a/core/src/analytics/event.rs
+++ b/core/src/analytics/event.rs
@@ -15,6 +15,11 @@ pub enum Event {
     DOWNLOAD_VERSION {
         version: String
     },
+    DOWNLOAD_VERSION_PROGRESS {
+        downloaded_file_url: String,
+        size_downloaded: u64,
+        size_remaining: u64,
+    },
     DOWNLOAD_VERSION_SUCCESS {
         version: String
     },
@@ -68,6 +73,7 @@ impl Display for Event {
             Event::LAUNCHER_OPEN {..} => "Launcher Open",
             Event::LAUNCHER_CLOSE {..} => "Launcher Close",
             Event::DOWNLOAD_VERSION {..} => "Download Version",
+            Event::DOWNLOAD_VERSION_PROGRESS {..} => "Download Version Progress",
             Event::DOWNLOAD_VERSION_SUCCESS {..} => "Download Version Success",
             Event::DOWNLOAD_VERSION_ERROR {..} => "Download Version Error",
             Event::DOWNLOAD_VERSION_CANCELLED {..} => "Download Version Cancelled",

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -242,9 +242,14 @@ impl LaunchStep for DownloadStep {
                 let target_path = installs::target_download_path();
                 let path: &str = target_path.to_str().context("Cannot convert target download path")?;
 
-                let mut analytics = self.analytics.lock().await;
-                analytics.track_and_flush(Event::DOWNLOAD_VERSION { version: version.clone() }).await?;
+                {
+                    let mut analytics = self.analytics.lock().await;
+                    analytics.track_and_flush(Event::DOWNLOAD_VERSION { version: version.clone() }).await?;
+                }
+
                 let result = installs::downloads::download_file(url, path, channel, &mode, self.analytics.clone()).await;
+
+                let mut analytics = self.analytics.lock().await;
                 if let Err(e) = result {
                     analytics.track_and_flush(Event::DOWNLOAD_VERSION_ERROR { version: Some(version.clone()), error: e.to_string() }).await?;
                 }

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -244,7 +244,7 @@ impl LaunchStep for DownloadStep {
 
                 let mut analytics = self.analytics.lock().await;
                 analytics.track_and_flush(Event::DOWNLOAD_VERSION { version: version.clone() }).await?;
-                let result = installs::downloads::download_file(url, path, channel, &mode).await;
+                let result = installs::downloads::download_file(url, path, channel, &mode, self.analytics.clone()).await;
                 if let Err(e) = result {
                     analytics.track_and_flush(Event::DOWNLOAD_VERSION_ERROR { version: Some(version.clone()), error: e.to_string() }).await?;
                 }

--- a/core/src/installs/downloads.rs
+++ b/core/src/installs/downloads.rs
@@ -7,8 +7,12 @@ use reqwest::Client;
 use crate::channel::EventChannel;
 use crate::types::{BuildType, Status, Step};
 use anyhow::{Context, Result};
+use crate::analytics::event::Event;
+use crate::analytics::Analytics;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
-pub async fn download_file<T: EventChannel>(url: &str, path: &str, channel: &T, build_type: &BuildType) -> Result<()> {
+pub async fn download_file<T: EventChannel>(url: &str, path: &str, channel: &T, build_type: &BuildType, analytics: Arc<Mutex<Analytics>>) -> Result<()> {
     let client = Client::new();
 
     let res = client
@@ -30,6 +34,18 @@ pub async fn download_file<T: EventChannel>(url: &str, path: &str, channel: &T, 
             .context(format!("Error while writing to file"))?;
         let new = min(downloaded + (chunk.len() as u64), total_size);
         downloaded = new;
+
+        {
+            let mut analytics_guard = analytics.lock().await;
+            let progress_event = Event::DOWNLOAD_VERSION_PROGRESS {
+                downloaded_file_url: url.to_string(),
+                size_downloaded: downloaded,
+                size_remaining: total_size - downloaded,
+            };
+            if let Err(e) = analytics_guard.track_and_flush(progress_event).await {
+                log::error!("Failed to track download progress event: {}", e);
+            }
+        }
 
         let progress: u8 = ((downloaded as f64 / total_size as f64) * 100.0) as u8;
         let event: Status = Status::State { 


### PR DESCRIPTION
Follow up PR to [chore: analytics improvements](https://github.com/decentraland/launcher-rust/pull/15). This PR implements the `Download Progress` event, which is sent every time the progress is calculated in `download_file` implementation. My aim is to hopefully detect slower client downloads, and determine if people fail to complete the launcher funnel because of this. 

@NickKhalow , let me know if you think this is something feasible to do, I'm not a rustacean myself so there might be a better way to tackle this. 