### PR TITLE
fix: update latest.json with S3 urls

### DIFF
--- a/.github/actions/upload-to-s3/action.yml
+++ b/.github/actions/upload-to-s3/action.yml
@@ -71,4 +71,23 @@ runs:
           fi
         done
 
+        DOMAIN="https://explorer-artifacts.decentraland.org"
+        TARGET_PATH="launcher-rust"
+        FILENAME_TAR="Decentraland.app.tar.gz"
+        FILENAME_EXE="Decentraland_x64-setup.exe"
+
+        if [[ -f "./latest.json" ]]; then
+          echo "Found latest.json at ./latest.json"
+
+          jq --arg tar_url "$DOMAIN/$TARGET_PATH/$FILENAME_TAR" \
+             --arg exe_url "$DOMAIN/$TARGET_PATH/$FILENAME_EXE" \
+            '.platforms["darwin-aarch64"].url = $tar_url |
+             .platforms["windows-x86_64"].url = $exe_url' \
+            ./latest.json > ./latest.json.tmp
+
+          mv ./latest.json.tmp ./latest.json
+          echo "Updated URLs in latest.json:"
+          cat ./latest.json
+        fi
+
         upload_file "./latest.json" "s3://${{ inputs.s3-bucket }}/${{ inputs.target-dir }}/latest.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EXPLORER_TEAM_AWS_DEFAULT_REGION }}
           s3-bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          target-dir: ${{ github.event.repository.name }}
+          target-dir: ${{ github.event.repository.name }}${{ (github.event_name != 'push' || github.ref_name != 'main') && '-temp' || '' }}
 
       - name: Upload Dry-Run artifacts to S3
         if: ${{ inputs.dry-run == true }}


### PR DESCRIPTION
- Fixed `latest.json` URLs for correct dmg/exe links
- Logged updated `latest.json` before uploading
- Added `-temp` suffix to target-dir when not pushing to `main` as a safety measure — prevents overwriting production artifacts unless it's a proper main release