### PR TITLE
chore: adjust store-release workflow

### DIFF
--- a/.github/actions/copy-in-s3/action.yml
+++ b/.github/actions/copy-in-s3/action.yml
@@ -1,0 +1,50 @@
+name: Copy artifacts in S3
+
+inputs:
+  aws-access-key-id:
+    required: true
+    description: "AWS Access Key ID"
+  aws-secret-access-key:
+    required: true
+    description: "AWS Secret Access Key"
+  aws-region:
+    required: true
+    description: "AWS Region"
+  s3-bucket:
+    required: true
+    description: "S3 Bucket name"
+  source-dir:
+    required: true
+    description: "Source S3 directory"
+  dest-dir:
+    required: true
+    description: "Destination S3 directory"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Copy artifacts in S3
+      shell: bash
+      run: |
+        set -e
+
+        export AWS_ACCESS_KEY_ID="${{ inputs.aws-access-key-id }}"
+        export AWS_SECRET_ACCESS_KEY="${{ inputs.aws-secret-access-key }}"
+        export AWS_DEFAULT_REGION="${{ inputs.aws-region }}"
+
+        # List files in source-dir
+        echo "Listing files to copy from: ${{
+          inputs.source-dir }}/"
+        files=$(aws s3 ls "s3://${{ inputs.s3-bucket }}/${{ inputs.source-dir }}/" | awk '{print $4}' || true)
+        if [[ -z "$files" ]]; then
+          echo "::error title=Copy artifacts in S3::No files found to copy in ./${{ inputs.source-dir }}/"
+          exit 1
+        fi
+
+        for file in $files; do
+          echo "Copying $file"
+          aws s3 cp "s3://${{ inputs.s3-bucket }}/${{ inputs.source-dir }}/$file" \
+                   "s3://${{ inputs.s3-bucket }}/${{ inputs.dest-dir }}/$file" --no-progress > /dev/null
+        done
+
+        echo "Copy complete."

--- a/.github/actions/get-short-sha/action.yml
+++ b/.github/actions/get-short-sha/action.yml
@@ -1,0 +1,39 @@
+name: Get Short SHA
+
+description: |
+  Consistently gets the short (7-char) commit SHA for both pull_request and other workflows,
+  or uses a manually supplied value if provided.
+
+inputs:
+  manual_short_sha:
+    description: "Optional 7-char commit SHA provided manually"
+    required: false
+
+outputs:
+  short_sha:
+    description: "The 7-character commit SHA"
+    value: ${{ steps.set_short_sha.outputs.short_sha }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: set_short_sha
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.manual_short_sha }}" ]; then
+          short_sha="${{ inputs.manual_short_sha }}"
+          if [[ ! "$short_sha" =~ ^[0-9a-fA-F]{7}$ ]]; then
+            echo "❌ Error: Provided manual_short_sha '$short_sha' is not a valid 7-character SHA."
+            exit 1
+          fi
+          echo "Using manually provided short SHA: $short_sha"
+        else
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            short_sha=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          else
+            short_sha=$(echo "$GITHUB_SHA" | cut -c1-7)
+          fi
+          echo "Calculated short SHA: $short_sha"
+        fi
+        echo "short_sha=$short_sha" >> $GITHUB_OUTPUT
+        echo "Short SHA: $short_sha"

--- a/.github/actions/upload-to-s3/action.yml
+++ b/.github/actions/upload-to-s3/action.yml
@@ -64,7 +64,6 @@ runs:
             for ext in $EXTENSIONS; do
               for file in *.$ext; do
                 upload_file "$file" "s3://${{ inputs.s3-bucket }}/${{ inputs.target-dir }}/$file"
-                upload_file "$file.sig" "s3://${{ inputs.s3-bucket }}/${{ inputs.target-dir }}/$file.sig"
               done
             done
             cd -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,10 @@ jobs:
             exit 1
           fi
 
+      - name: Get short SHA
+        id: shortsha
+        uses: ./.github/actions/get-short-sha
+
       - name: Upload Release artifacts to S3
         if: ${{ inputs.dry-run == false }}
         uses: ./.github/actions/upload-to-s3
@@ -276,7 +280,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EXPLORER_TEAM_AWS_DEFAULT_REGION }}
           s3-bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          target-dir: ${{ github.event.repository.name }}${{ (github.event_name != 'push' || github.ref_name != 'main') && '-temp' || '' }}
+          target-dir: draft-release-${{ github.event.repository.name }}-${{ steps.shortsha.outputs.short_sha }}
 
       - name: Upload Dry-Run artifacts to S3
         if: ${{ inputs.dry-run == true }}

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: 
       - published
+  workflow_dispatch:
+    inputs:
+      short_sha:
+        description: "Optional 7-character short SHA to use for artifact lookup"
+        required: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -15,13 +20,7 @@ defaults:
 
 jobs:
   store-release:
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ macos-latest, windows-latest ]
-        store: [ dcl, itch.io ]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -30,80 +29,16 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Get short SHA
+        id: shortsha
+        uses: ./.github/actions/get-short-sha
+
+      - name: Copy artifacts in S3
+        uses: ./.github/actions/copy-in-s3
         with:
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      
-      - name: Get Release Tag
-        id: release_tag
-        run: |
-          echo "RELEASE_TAG=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-
-      - name: Build Release for ${{ matrix.store }}
-        run: npm run build
-        env:
-          MODE: production
-          VITE_PROVIDER: ${{ matrix.store }}
-          # Segment API Key
-          VITE_SEGMENT_API_KEY: ${{ secrets.SEGMENT_API_KEY }}
-          # Sentry AUTH Token
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          VITE_AWS_S3_BUCKET_PUBLIC_URL: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
-
-      # Download 'SSLcom/esigner-codesign' to a folder called 'esigner-codesign' in the root of the project
-      - name: Checkout esigner-codesign repository (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: actions/checkout@v3
-        with:
-          repository: 'SSLcom/esigner-codesign'
-          path: esigner-codesign
-
-      - name: Compile artifacts and upload them to S3
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 6
-          retry_wait_seconds: 15
-          retry_on: error
-          shell: 'bash'
-          command: npx electron-builder --config electron-store-builder.cjs -c.extraMetadata.version=${{ steps.release_tag.outputs.release_tag }} -c.mac.notarize.teamId=${{ env.APPLE_TEAM_ID }} --publish always
-        env:
-          # Code Signing params
-          # See https://www.electron.build/code-signing
-          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
-          # Notarization params
-          # See https://www.electron.build/configuration/mac#NotarizeNotaryOptions
-          APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_PWD }}
-          APPLE_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
-          # Publishing artifacts
-          RELEASE_TAG: ${{ steps.release_tag.outputs.release_tag }}
-          GH_TOKEN: ${{ secrets.github_token }}
-          # The following are the parameters required by the esigner-codesign action to work, we must explicitly pass in even the optional ones since we're not using the action directly, but from the checked out repo
-          CODE_SIGN_SCRIPT_PATH: "${{ github.workspace }}\\esigner-codesign\\dist\\index.js"
-          INPUT_COMMAND: "sign"
-          INPUT_FILE_PATH: "${{ github.workspace }}\\dist\\Decentraland Launcher-win-x64.exe"
-          INPUT_OVERRIDE: "true"
-          INPUT_MALWARE_BLOCK: "false"
-          INPUT_CLEAN_LOGS: "false"
-          INPUT_JVM_MAX_MEMORY: "1024M"
-          INPUT_ENVIRONMENT_NAME: "PROD"
-          INPUT_USERNAME: ${{ secrets.ES_USERNAME }}
-          INPUT_PASSWORD: ${{ secrets.ES_PASSWORD }}
-          INPUT_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
-          INPUT_CREDENTIAL_ID: ${{ secrets.WINDOWS_CREDENTIAL_ID_SIGNER }}
-          # # S3 Params
-          # AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
-          # AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
-          # AWS_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          # AWS_DEFAULT_REGION: ${{ secrets.EXPLORER_TEAM_AWS_DEFAULT_REGION }}
-          # Additional params to build the launcher
-          PROVIDER: ${{ matrix.store }}
+          aws-access-key-id: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.EXPLORER_TEAM_AWS_DEFAULT_REGION }}
+          s3-bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
+          source-dir: draft-release-${{ github.event.repository.name }}-${{ steps.shortsha.outputs.short_sha }}
+          dest-dir: ${{ github.event.repository.name }}


### PR DESCRIPTION
- Added a new action to copy files between S3 folders, with clear error output if nothing is found.
- Introduced a custom action to reliably get a 7-character short SHA for artifacts, which works both automatically and with manual override (with validation).
- Cleaned up the S3 upload action to remove *.sig artifact uploads.
- Updated both release.yml and store-release.yml workflows to use the new SHA logic for directory naming, and added support for entering the short SHA manually in store-release.yml.
- Simplified the store-release workflow by removing old matrix configs and unused steps.