### PR TITLE
fix: cannot send event error

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "0.1.0"
+version = "1.0.14"
 dependencies = [
  "anyhow",
  "deranged",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -67,12 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "deranged",
@@ -365,15 +359,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -590,25 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "h2"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,7 +673,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1491,11 +1456,9 @@ checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1519,7 +1482,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -1589,6 +1551,7 @@ version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1705,6 +1668,7 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest",
+ "rustls",
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
@@ -1715,6 +1679,7 @@ dependencies = [
  "sentry-tracing",
  "tokio",
  "ureq",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1969,27 +1934,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2282,7 +2226,10 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "anyhow",
  "deranged",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcl-launcher-core"
-version = "1.0.15"
+version = "1.0.16"
 edition = "2024"
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcl-launcher-core"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2024"
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ plist = "=1.7.0"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 regex = "1.11.1"
 anyhow = "1.0.97"
 
@@ -47,12 +47,12 @@ fern = "0.7.1"
 pretty_env_logger = "0.5.0"
 humantime = "2.2.0"
 
-segment = "0.2.6"
+segment = { version = "0.2.6", default-features = false, features = ["rustls-tls"] }
 uuid = { version = "1.16.0", features = ["v4"] }
 
 nix =  { version = "0.29.0", features = ["process"] }
 
-sentry = { version = "0.37.0", features = ["anyhow", "log", "reqwest", "backtrace"] }
+sentry = { version = "0.37.0", features = ["anyhow", "log", "reqwest", "rustls", "backtrace"] }
 sentry-anyhow = { version = "0.37.0" }
 sentry-log = "0.37.0"
 sentry-types = "0.37.0"

--- a/core/src/analytics.rs
+++ b/core/src/analytics.rs
@@ -41,10 +41,7 @@ impl Analytics {
                 info!(
                     "SEGMENT_API_KEY is set successfully from environment variable, segment is available"
                 );
-                let anonymous_id = config::user_id().unwrap_or_else(|e| {
-                    error!("Cannot get user id from config, fallback is used: {:#}", e);
-                    "none".to_owned()
-                });
+                let anonymous_id = config::user_id_or_none();
                 let launcher_version = app_version().to_owned();
                 let os = get_os_name().to_owned();
                 let args = CreateArgs {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, anyhow};
+use log::error;
 use serde_json::{Map, Value};
 
 use crate::installs::config_path;
@@ -21,7 +22,7 @@ fn write_config(value: Map<String, Value>) -> Result<()> {
     Ok(())
 }
 
-pub fn user_id() -> Result<String> {
+fn user_id() -> Result<String> {
     const KEY: &str = "analytics-user-id";
     let config = config_content()?;
     if let Some(id) = config.get(KEY) {
@@ -41,4 +42,11 @@ pub fn user_id() -> Result<String> {
     config.insert(KEY.to_owned(), Value::String(id.clone()));
     write_config(config)?;
     Ok(id)
+}
+
+pub fn user_id_or_none() -> String {
+    user_id().unwrap_or_else(|e| {
+        error!("Cannot get user id from config, fallback is used: {:#}", e);
+        "none".to_owned()
+    })
 }

--- a/core/src/monitoring.rs
+++ b/core/src/monitoring.rs
@@ -3,8 +3,10 @@ use std::str::FromStr;
 use anyhow::Result;
 use log::{error, info};
 
-use sentry::ClientOptions;
+use sentry::{ClientOptions, protocol::User};
 use sentry_types::Dsn;
+
+use crate::config;
 
 pub struct Monitoring {}
 
@@ -35,6 +37,18 @@ impl Monitoring {
                 // keeps guard for the whole lifetime of the app
                 std::mem::forget(guard);
                 info!("sentry dns initialized successfully");
+
+                // Set user scope
+                let user_id = config::user_id_or_none();
+                info!("sentry user_id {}", user_id);
+
+                sentry::configure_scope(|scope| {
+                    scope.set_user(Some(User {
+                        id: Some(user_id),
+                        ..Default::default()
+                    }));
+                });
+
                 Ok(())
             }
         }

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use log::error;
+use log::{error, warn};
 
 static PROTOCOL_STATE: Mutex<Option<String>> = Mutex::new(None);
 const PROTOCOL_PREFIX: &str = "decentraland://";
@@ -48,7 +48,7 @@ impl Protocol {
             }
         }
 
-        error!(
+        warn!(
             "none of values starts with prefix protocol {}: {:?}",
             PROTOCOL_PREFIX, value
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Decentraland",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Decentraland",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Decentraland",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Decentraland",
   "private": true,
-  "version": "1.0.15",
+  "version": "1.0.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Decentraland-Launcher"
-version = "1.0.4"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "dcl-launcher-core",
@@ -134,12 +134,6 @@ dependencies = [
  "libc",
  "system-deps",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -663,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "0.1.0"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "deranged",
@@ -900,15 +894,6 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "env_logger"
@@ -1468,25 +1453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.8.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,7 +1589,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -3286,11 +3251,9 @@ checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3314,7 +3277,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -3395,6 +3357,7 @@ version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3570,6 +3533,7 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest",
+ "rustls",
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
@@ -3580,6 +3544,7 @@ dependencies = [
  "sentry-tracing",
  "tokio",
  "ureq",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4062,27 +4027,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4906,7 +4850,10 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/main.rs"
 
 [package]
 name = "Decentraland-Launcher"
-version = "1.0.14"
+version = "1.0.15"
 description = "Decentraland Launcher App"
 authors = [ "Decentraland",]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/main.rs"
 
 [package]
 name = "Decentraland-Launcher"
-version = "1.0.15"
+version = "1.0.16"
 description = "Decentraland Launcher App"
 authors = [ "Decentraland",]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Decentraland",
   "mainBinaryName": "dcl_launcher",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "identifier": "com.decentraland.launcherlite",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Decentraland",
   "mainBinaryName": "dcl_launcher",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "identifier": "com.decentraland.launcherlite",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Investigation

In results of the investigation of sentry dashboard the following is concluded:

1. Issue is Windows only. To revalidate apply the following filter: `issue:LAUNCHER-RUST-5R message:"Cannot send event: Error" os.name:macOS`. Issue is caused most likely due the specifics of native TLS certificates implementation on the OS
2. Each related error is caused by `NetworkError` of Segment. Underlying details vary: "TimedOut", "No such host is known", "dns error", "The token supplied to the function is invalid", "unexpected EOF during handshake", "code: 10054", "IncompleteMessage". To revalidate put the following filter in the dashboard's search: `issue:LAUNCHER-RUST-5R message:"Cannot send event: Error" !message:TimedOut !message:"No such host is known" !message:"dns error" !message:"The token supplied to the function is invalid" !message:"unexpected EOF during handshake" !message:"code: 10054" !message:IncompleteMessage`
3. After the updates from the PR we will be able to investigate https://github.com/decentraland/launcher-rust/issues/52 ticket, because it's directly dependent on how well do segment reports perform

## Changes

1. native-tls certificates are replaced with rust-tls
2. Added user scope information to enhance reports with `anon_id` to sentry for better tracing the errors
4. Report of `decentraland://` is downgraded from `error` to `warn` to distress the channel from none-informative message reports

## Test Instruction

1. Use windows machine
5. Download the build from this PR and launch it, execute smoke test normally. No flow changes are expected
6. Find in the logs your user_id by `sentry user_id` filter, logs must have only one message per session. It should look like `sentry user_id 1e037089-3a19-40d4-8e34-h10eb1020e8c`
7. Provide user_id to me (@NickKhalow), I will ensure no the related sentry errors were reported to dashboard
8. To ensure the problem won't occur on mac make an extra recheck with the same test flow