### PR TITLE
chore: remove not needed path-ignore from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,33 +9,7 @@ on:
     branches:
       - main
       - 'renovate/**'
-    paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/ci.yml'
-      - '!.github/workflows/typechecking.yml'
-      - '!.github/workflows/tests.yml'
-      - '!.github/workflows/release.yml'
-      - '!.github/workflows/pr-deploy-status.yml'
-      - '!.github/workflows/auto-label-issues.yml'
-      - '**.md'
-      - .editorconfig
-      - .gitignore
-      - '.idea/**'
-      - '.vscode/**'
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/ci.yml'
-      - '!.github/workflows/typechecking.yml'
-      - '!.github/workflows/tests.yml'
-      - '!.github/workflows/release.yml'
-      - '!.github/workflows/pr-deploy-status.yml'
-      - '!.github/workflows/auto-label-issues.yml'
-      - '**.md'
-      - .editorconfig
-      - .gitignore
-      - '.idea/**'
-      - '.vscode/**'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
- Removed paths-ignore from `ci.yml`
- Ensures CI runs on all PRs, regardless of which files were changed
- Fixes cases where CI was unintentionally skipped (e.g., on workflow or doc updates)