### PR TITLE
chore: version consistency check

### DIFF
--- a/update_version.rs
+++ b/update_version.rs
@@ -19,6 +19,20 @@ const APP_CONFIG_LOCK: &str = "src-tauri/tauri.conf.json";
 const APP_RS_TOML: &str = "src-tauri/Cargo.toml";
 const CORE_RS_TOML: &str = "core/Cargo.toml";
 
+const FILES: [&'static str; 5] = [
+    PACKAGE_JSON,
+    PACKAGE_JSON_LOCK,
+    APP_CONFIG_LOCK,
+    APP_RS_TOML,
+    CORE_RS_TOML,
+];
+
+#[derive(Debug)]
+struct VersionPair {
+    path: &'static str,
+    version: Version,
+}
+
 #[derive(Debug)]
 enum BumpType {
     Major,
@@ -84,6 +98,62 @@ fn update_toml_version(path: &str, bump: &BumpType) -> Result<()> {
     Ok(())
 }
 
+fn update_version(path: &str, bump: &BumpType) -> Result<()> {
+    if path.ends_with(".json") {
+        update_json_version(path, bump)
+    }
+    else if path.ends_with(".toml") {
+        update_toml_version(path, bump)
+    }
+    else {
+        Err(anyhow!("File type of {} is unsupported", path))
+    }
+}
+
+fn version_from_toml(path: &str) -> Result<Version> {
+    let raw = fs::read_to_string(path).context("Failed to read TOML")?;
+    let doc: DocumentMut = raw.parse().context("Failed to parse TOML")?;
+    let version = doc["package"]["version"].as_str().context("Cannot get version field")?.to_owned();
+    let parsed = Version::parse(&version)?;
+    Ok(parsed)
+}
+
+fn version_from_json(path: &str) -> Result<Version> {
+    let raw = fs::read_to_string(path).context("Failed to read JSON")?;
+    let json: serde_json::Value = serde_json::from_str(&raw)?;
+    let old_version = json["version"].as_str().context("Cannot get version field")?.to_owned();
+    let parsed = Version::parse(&old_version)?;
+    Ok(parsed)
+}
+
+fn version_from(path: &str) -> Result<Version> {
+    if path.ends_with(".json") {
+        version_from_json(path)
+    }
+    else if path.ends_with(".toml") {
+        version_from_toml(path)
+    }
+    else {
+        Err(anyhow!("File type of {} is unsupported", path))
+    }
+}
+
+fn ensure_versions_are_equal(versions: Vec<VersionPair>) -> Result<()> {
+    match versions.first() {
+        Some(first) => {
+            if versions.iter().any(|v| v.version != first.version) {
+                Err(anyhow!("Not all versions are equal: {:#?}", versions))
+            }
+            else {
+                Ok(())
+            }
+        },
+        None => {
+            Ok(())
+        }
+    }
+}
+
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
@@ -93,11 +163,21 @@ fn main() -> Result<()> {
 
     let bump = BumpType::from_str(&args[1])?;
 
-    update_json_version(PACKAGE_JSON, &bump).context("Cannot bump PACKAGE_JSON")?;
-    update_json_version(PACKAGE_JSON_LOCK, &bump).context("Cannot bump PACKAGE_JSON_LOCK")?;
-    update_json_version(APP_CONFIG_LOCK, &bump).context("Cannot bump APP_CONFIG_LOCK")?;
-    update_toml_version(APP_RS_TOML, &bump).context("Cannot bump APP_RS_TOML")?;
-    update_toml_version(CORE_RS_TOML, &bump).context("Cannot bump CORE_RS_TOML")?;
+    let versions = FILES
+        .iter()
+        .map(|path| {
+            let version = version_from(path)?;
+            Ok(VersionPair { path, version })
+        })
+        .collect::<Result<_>>()?;
+
+
+    ensure_versions_are_equal(versions)?;
+
+    for path in FILES {
+        update_version(path, &bump)
+            .with_context(|| format!("Cannot bump version in {}", path))?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- added generic method for update_version for toml and json
- added consistency check that ensures versions are the same before bumping