### PR TITLE
feat: straitforward pasring for cmd args

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -38,56 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,52 +179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,7 +254,6 @@ name = "dcl-launcher-core"
 version = "1.5.2"
 dependencies = [
  "anyhow",
- "clap",
  "deranged",
  "dirs",
  "fern",
@@ -679,12 +582,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1018,12 +915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,12 +1126,6 @@ name = "once_cell"
 version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -2046,12 +1931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,12 +2300,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -38,6 +38,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +229,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,9 +347,10 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
+ "clap",
  "deranged",
  "dirs",
  "fern",
@@ -582,6 +679,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -915,6 +1018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1235,12 @@ name = "once_cell"
 version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -1931,6 +2046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2421,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -65,3 +65,4 @@ sentry-log = "0.37.0"
 sentry-types = "0.37.0"
 
 windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }
+clap = { version = "4.5.41", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -65,4 +65,3 @@ sentry-log = "0.37.0"
 sentry-types = "0.37.0"
 
 windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }
-clap = { version = "4.5.41", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcl-launcher-core"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcl-launcher-core"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2024"
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcl-launcher-core"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 
 [lib]

--- a/core/src/analytics.rs
+++ b/core/src/analytics.rs
@@ -30,7 +30,7 @@ pub enum Analytics {
 
 impl Analytics {
     pub fn new_from_env() -> Self {
-        if AppEnvironment::cmd_args().any(|e| e == "--skip-analytics") {
+        if AppEnvironment::cmd_args().skip_analytics {
             info!("SEGMENT_API_KEY running with --skip-analytics, segment is not available");
             return Self::new(None);
         }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -1,3 +1,4 @@
+use clap::ArgAction;
 use log::info;
 
 use crate::config;
@@ -37,7 +38,10 @@ impl Args {
                 || other.open_deeplink_in_new_instance,
             always_trigger_updater: self.always_trigger_updater || other.always_trigger_updater,
             never_trigger_updater: self.never_trigger_updater || other.never_trigger_updater,
-            use_updater_url: self.use_updater_url.clone().or_else(|| other.use_updater_url.clone()),
+            use_updater_url: self
+                .use_updater_url
+                .clone()
+                .or_else(|| other.use_updater_url.clone()),
         }
     }
 }
@@ -108,21 +112,148 @@ fn build_command() -> clap::Command {
     use clap::Command;
 
     Command::new("dcl_launcher")
-        .arg(Arg::new("skip_analytics").long("skip-analytics"))
-        .arg(Arg::new("open_deeplink_in_new_instance").long("open-deeplink-in-new-instance"))
-        .arg(Arg::new("always_trigger_updater").long("always-trigger-updater"))
-        .arg(Arg::new("never_trigger_updater").long("never-trigger-updater"))
-        .arg(Arg::new("use_updater_url").long("use-updater-url"))
+        .arg(
+            Arg::new("skip_analytics")
+                .long("skip-analytics")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("open_deeplink_in_new_instance")
+                .long("open-deeplink-in-new-instance")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("always_trigger_updater")
+                .long("always-trigger-updater")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("never_trigger_updater")
+                .long("never-trigger-updater")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("use_updater_url")
+                .long("use-updater-url")
+                .value_name("URL")
+                .num_args(0..=1),
+        ) // optional
         .allow_external_subcommands(true)
 }
 
+fn filter_known_args(args: impl Iterator<Item = String>) -> impl Iterator<Item = String> {
+    let known = [
+        "--skip-analytics",
+        "--open-deeplink-in-new-instance",
+        "--always-trigger-updater",
+        "--never-trigger-updater",
+        "--use-updater-url",
+    ];
+
+    args.filter(move |e| {
+        if e.starts_with("--") {
+            known.contains(&e.as_str())
+        } else {
+            // ignore none flags
+            true
+        }
+    })
+}
+
 fn parse(i: impl Iterator<Item = String>) -> Result<Args, clap::Error> {
-    let matches = build_command().try_get_matches_from(i)?;
+    let args = filter_known_args(i);
+    let matches = build_command().try_get_matches_from(args)?;
     Ok(Args {
-        skip_analytics: matches.contains_id("skip_analytics"),
-        open_deeplink_in_new_instance: matches.contains_id("open_deeplink_in_new_instance"),
-        always_trigger_updater: matches.contains_id("always_trigger_updater"),
-        never_trigger_updater: matches.contains_id("never_trigger_updater"),
+        skip_analytics: matches
+            .get_one::<bool>("skip_analytics")
+            .copied()
+            .unwrap_or(false),
+        open_deeplink_in_new_instance: matches
+            .get_one::<bool>("open_deeplink_in_new_instance")
+            .copied()
+            .unwrap_or(false),
+        always_trigger_updater: matches
+            .get_one::<bool>("always_trigger_updater")
+            .copied()
+            .unwrap_or(false),
+        never_trigger_updater: matches
+            .get_one::<bool>("never_trigger_updater")
+            .copied()
+            .unwrap_or(false),
         use_updater_url: matches.get_one::<String>("use_updater_url").cloned(),
     })
+}
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::*;
+
+    #[test]
+    fn test_known_args_parsed() -> Result<()> {
+        let args = parse(
+            [
+                "app",
+                "--skip-analytics",
+                "--open-deeplink-in-new-instance",
+                "--use-updater-url",
+                "https://example.com",
+            ]
+            .map(|e| e.to_owned())
+            .into_iter(),
+        )?;
+
+        assert!(args.skip_analytics);
+        assert!(args.open_deeplink_in_new_instance);
+        assert!(!args.always_trigger_updater);
+        assert_eq!(args.use_updater_url.as_deref(), Some("https://example.com"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_unknown_args_ignored() -> Result<()> {
+        let args = parse(
+            [
+                "app",
+                "--skip-analytics",
+                "--unknown-flag",
+                "--use-updater-url",
+                "https://example.com",
+            ]
+            .map(|e| e.to_owned())
+            .into_iter(),
+        )?;
+
+        assert!(args.skip_analytics);
+        assert!(args.use_updater_url.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_with() {
+        let a = Args {
+            skip_analytics: true,
+            open_deeplink_in_new_instance: false,
+            always_trigger_updater: true,
+            never_trigger_updater: false,
+            use_updater_url: Some("https://one.com".into()),
+        };
+
+        let b = Args {
+            skip_analytics: false,
+            open_deeplink_in_new_instance: true,
+            always_trigger_updater: false,
+            never_trigger_updater: true,
+            use_updater_url: Some("https://two.com".into()),
+        };
+
+        let merged = a.merge_with(&b);
+
+        assert!(merged.skip_analytics);
+        assert!(merged.open_deeplink_in_new_instance);
+        assert!(merged.always_trigger_updater);
+        assert!(merged.never_trigger_updater);
+        // Should keep first if present
+        assert_eq!(merged.use_updater_url.as_deref(), Some("https://one.com"));
+    }
 }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -1,3 +1,6 @@
+use clap::Parser;
+use log::info;
+
 use crate::config;
 
 const DEFAULT_PROVIDER: &str = "dcl";
@@ -14,6 +17,21 @@ pub enum LauncherEnvironment {
 }
 
 pub struct AppEnvironment {}
+
+#[derive(clap::Parser, Debug)]
+pub struct Args {
+    #[arg(long)]
+    pub skip_analytics: bool,
+    #[arg(long)]
+    pub open_deeplink_in_new_instance: bool,
+
+    #[arg(long)]
+    pub always_trigger_updater: bool,
+    #[arg(long)]
+    pub never_trigger_updater: bool,
+    #[arg(long)]
+    pub use_updater_url: Option<String>,
+}
 
 impl AppEnvironment {
     pub fn provider() -> String {
@@ -36,9 +54,14 @@ impl AppEnvironment {
         }
     }
 
-    pub fn cmd_args() -> impl Iterator<Item = String> {
-        let direct = std::env::args();
-        let config = config::cmd_arguments();
-        direct.chain(config)
+    pub fn cmd_args() -> Args {
+        let from_cmd = std::env::args();
+        info!("cmd args: {:?}", from_cmd);
+
+        let from_config = config::cmd_arguments();
+        info!("config args: {:?}", from_config);
+
+        let raw = from_cmd.chain(from_config);
+        Args::parse_from(raw)
     }
 }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -29,14 +29,15 @@ pub struct Args {
 }
 
 impl Args {
+    #[must_use]
     pub fn merge_with(&self, other: &Self) -> Self {
-        Args {
+        Self {
             skip_analytics: self.skip_analytics || other.skip_analytics,
             open_deeplink_in_new_instance: self.open_deeplink_in_new_instance
                 || other.open_deeplink_in_new_instance,
             always_trigger_updater: self.always_trigger_updater || other.always_trigger_updater,
             never_trigger_updater: self.never_trigger_updater || other.never_trigger_updater,
-            use_updater_url: self.use_updater_url.clone().or(other.use_updater_url.clone()),
+            use_updater_url: self.use_updater_url.clone().or_else(|| other.use_updater_url.clone()),
         }
     }
 }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -19,7 +19,7 @@ pub enum LauncherEnvironment {
 pub struct AppEnvironment {}
 
 #[allow(clippy::struct_excessive_bools)]
-#[derive(clap::Parser, Debug)]
+#[derive(clap::Parser, Debug, Default)]
 pub struct Args {
     #[arg(long)]
     pub skip_analytics: bool,
@@ -57,7 +57,14 @@ impl AppEnvironment {
 
     pub fn cmd_args() -> Args {
         let raw = Self::raw_cmd_args();
-        Args::parse_from(raw)
+        let args = Args::try_parse_from(raw);
+        match args {
+            Ok(args) => args,
+            Err(e) => {
+                log::error!("cannot pass args, fallback to default args: {}", e);
+                Args::default()
+            }
+        }
     }
 
     pub fn raw_cmd_args() -> impl Iterator<Item = String> {

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -18,6 +18,7 @@ pub enum LauncherEnvironment {
 
 pub struct AppEnvironment {}
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(clap::Parser, Debug)]
 pub struct Args {
     #[arg(long)]

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -56,13 +56,17 @@ impl AppEnvironment {
     }
 
     pub fn cmd_args() -> Args {
+        let raw = Self::raw_cmd_args();
+        Args::parse_from(raw)
+    }
+
+    pub fn raw_cmd_args() -> impl Iterator<Item = String> {
         let from_cmd = std::env::args();
         info!("cmd args: {:?}", from_cmd);
 
         let from_config = config::cmd_arguments();
         info!("config args: {:?}", from_config);
 
-        let raw = from_cmd.chain(from_config);
-        Args::parse_from(raw)
+        from_cmd.chain(from_config)
     }
 }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -74,7 +74,10 @@ impl AppEnvironment {
     pub fn cmd_args() -> Args {
         let args = Self::cmd_args_internal();
         match args {
-            Ok(args) => args,
+            Ok(args) => {
+                log::info!("parsed args: {:#?}", args);
+                args
+            }
             Err(e) => {
                 log::error!("cannot pass args, fallback to default args: {}", e);
                 Args::default()

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -425,8 +425,7 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
 
         match self.protocol.value() {
             Some(deeplink) => {
-                let open_new_instance =
-                    AppEnvironment::cmd_args().any(|e| e == "--open-deeplink-in-new-instance");
+                let open_new_instance = AppEnvironment::cmd_args().open_deeplink_in_new_instance;
                 let any_is_running = self.is_any_instance_running().await?;
                 if !open_new_instance && any_is_running {
                     channel.send(Status::State {

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -2,8 +2,6 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::env;
 
-use crate::environment::AppEnvironment;
-
 #[must_use]
 pub fn get_os_name() -> &'static str {
     let os = std::env::consts::OS;
@@ -12,34 +10,6 @@ pub fn get_os_name() -> &'static str {
         "windows" => "windows64",
         _ => "unsupported",
     }
-}
-
-#[must_use]
-pub fn parsed_argv() -> HashMap<String, String> {
-    let mut parsed_argv = HashMap::new();
-    let args: Vec<String> = AppEnvironment::cmd_args().collect();
-
-    for arg in &args {
-        if let Some((key, value)) = arg.strip_prefix("--").and_then(|s| s.split_once('=')) {
-            match key {
-                "version" | "prerelease" | "dev" | "downloadedfilepath" => {
-                    // don't need to handle overwrites
-                    let _ = parsed_argv.insert(key.to_string(), value.to_string());
-                }
-                _ => {}
-            }
-        } else if let Some(key) = arg.strip_prefix("--") {
-            match key {
-                "version" | "prerelease" | "dev" | "downloadedfilepath" => {
-                    // don't need to handle overwrites
-                    let _ = parsed_argv.insert(key.to_string(), "true".to_string());
-                }
-                _ => {}
-            }
-        }
-    }
-
-    parsed_argv
 }
 
 fn is_valid_version(version: &str) -> bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Decentraland",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Decentraland",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Decentraland",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Decentraland",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Decentraland",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Decentraland",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Decentraland-Launcher"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "dcl-launcher-core",
@@ -81,6 +81,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -418,6 +468,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,9 +753,10 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
+ "clap",
  "deranged",
  "dirs 5.0.1",
  "fern",
@@ -1902,6 +1999,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,6 +2698,12 @@ name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -4944,6 +5053,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Decentraland-Launcher"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "dcl-launcher-core",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/main.rs"
 
 [package]
 name = "Decentraland-Launcher"
-version = "1.4.1"
+version = "1.5.0"
 description = "Decentraland Launcher App"
 authors = [ "Decentraland",]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/main.rs"
 
 [package]
 name = "Decentraland-Launcher"
-version = "1.5.0"
+version = "1.5.1"
 description = "Decentraland Launcher App"
 authors = [ "Decentraland",]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/main.rs"
 
 [package]
 name = "Decentraland-Launcher"
-version = "1.5.1"
+version = "1.5.2"
 description = "Decentraland Launcher App"
 authors = [ "Decentraland",]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -193,7 +193,7 @@ fn setup_deeplink(a: &App, protocol: &Protocol) {
 
     #[cfg(target_os = "windows")]
     {
-        let args: Vec<String> = AppEnvironment::cmd_args().collect();
+        let args: Vec<String> = AppEnvironment::raw_cmd_args().collect();
         protocol.try_assign_value_from_vec(&args);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@
 )]
 #![allow(clippy::uninlined_format_args, clippy::used_underscore_binding)]
 
-use dcl_launcher_core::environment::AppEnvironment;
+use dcl_launcher_core::environment::{AppEnvironment, Args};
 use dcl_launcher_core::errors::FlowError;
 use dcl_launcher_core::log::{error, info};
 use dcl_launcher_core::protocols::Protocol;
@@ -83,48 +83,29 @@ async fn launch(
 }
 
 fn current_updater(app: &AppHandle) -> tauri_plugin_updater::Result<tauri_plugin_updater::Updater> {
-    const KEY_UPDATER_URL: &str = "--use-updater-url";
-    const KEY_ALWAYS_TRIGGER_UPDATER: &str = "--always-trigger-updater";
-    const KEY_NEVER_TRIGGER_UPDATER: &str = "--never-trigger-updater";
-
-    let args: Vec<String> = AppEnvironment::cmd_args().collect();
+    let args: Args = AppEnvironment::cmd_args();
 
     // comparison to support rollbacks
-    let compare_args = args.clone();
     let builder = app
         .updater_builder()
         .version_comparator(move |current_version, remote| {
-            if compare_args.iter().any(|a| a == KEY_NEVER_TRIGGER_UPDATER) {
-                info!("Never trigger updater by flag {}", KEY_UPDATER_URL);
+            if args.never_trigger_updater {
+                info!("Never trigger updater by flag");
                 return false;
             }
 
-            if compare_args.iter().any(|a| a == KEY_ALWAYS_TRIGGER_UPDATER) {
-                info!("Always trigger updater by flag {}", KEY_UPDATER_URL);
+            if args.always_trigger_updater {
+                info!("Always trigger updater by flag");
                 return true;
             }
 
             current_version != remote.version
         });
 
-    if let Some(pos) = args.iter().position(|a| a == KEY_UPDATER_URL) {
-        let url = args.get(pos.saturating_add(1));
-        match url {
-            Some(url) => {
-                info!(
-                    "Use custom updater by flag {} with its value {}",
-                    KEY_UPDATER_URL, url
-                );
-                let parsed_url: Url = Url::parse(url)?;
-                return builder.endpoints(vec![parsed_url])?.build();
-            }
-            None => {
-                error!(
-                    "Flag {} is provided but its value is missed",
-                    KEY_UPDATER_URL
-                );
-            }
-        }
+    if let Some(url) = args.use_updater_url {
+        info!("Use custom updater by flag with its value {}", url);
+        let parsed_url: Url = Url::parse(url.as_str())?;
+        return builder.endpoints(vec![parsed_url])?.build();
     }
 
     builder.build()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Decentraland",
   "mainBinaryName": "dcl_launcher",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "com.decentraland.launcherlite",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Decentraland",
   "mainBinaryName": "dcl_launcher",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "identifier": "com.decentraland.launcherlite",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Decentraland",
   "mainBinaryName": "dcl_launcher",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.decentraland.launcherlite",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
# Changes

Added strait-forward argument parsing with support arguments both from cmd and the config file. To check all available arguments run app with `--help` argument

# Test Instruction

1. Validate each argument works as before the update
2. Smoke test (including creator hub)