### PR TITLE
feat: distinguish normal instances and local scene development instances for deep links

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
+ "url",
  "uuid",
  "windows-sys 0.59.0",
  "zip",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.5.2"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "deranged",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 regex = "1.11.1"
+url = "2.5.4"
 anyhow = "1.0.97"
 
 futures-util = "0.3.14"

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -13,6 +13,7 @@ const ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE: &str = "open-deeplink-in-new-instance";
 const ARG_ALWAYS_TRIGGER_UPDATER: &str = "always-trigger-updater";
 const ARG_NEVER_TRIGGER_UPDATER: &str = "never-trigger-updater";
 const ARG_USE_UPDATER_URL: &str = "use-updater-url";
+const ARG_LOCAL_SCENE: &str = "local-scene";
 
 #[derive(Debug)]
 pub enum LauncherEnvironment {
@@ -32,6 +33,9 @@ pub struct Args {
     pub always_trigger_updater: bool,
     pub never_trigger_updater: bool,
     pub use_updater_url: Option<String>,
+
+    // used by the client
+    pub local_scene: bool,
 }
 
 impl Args {
@@ -47,6 +51,7 @@ impl Args {
                 .use_updater_url
                 .clone()
                 .or_else(|| other.use_updater_url.clone()),
+            local_scene: self.local_scene || other.local_scene,
         }
     }
 
@@ -62,6 +67,7 @@ impl Args {
             always_trigger_updater: Self::has_flag(ARG_ALWAYS_TRIGGER_UPDATER, &vector),
             never_trigger_updater: Self::has_flag(ARG_NEVER_TRIGGER_UPDATER, &vector),
             use_updater_url: Self::value_by_flag(ARG_USE_UPDATER_URL, &vector),
+            local_scene: Self::has_flag(ARG_LOCAL_SCENE, &vector),
         }
     }
 
@@ -206,6 +212,7 @@ mod tests {
             always_trigger_updater: true,
             never_trigger_updater: false,
             use_updater_url: Some("https://one.com".into()),
+            local_scene: false,
         };
 
         let b = Args {
@@ -214,6 +221,7 @@ mod tests {
             always_trigger_updater: false,
             never_trigger_updater: true,
             use_updater_url: Some("https://two.com".into()),
+            local_scene: false
         };
 
         let merged = a.merge_with(&b);
@@ -222,6 +230,7 @@ mod tests {
         assert!(merged.open_deeplink_in_new_instance);
         assert!(merged.always_trigger_updater);
         assert!(merged.never_trigger_updater);
+        assert!(!merged.local_scene);
         // Should keep first if present
         assert_eq!(merged.use_updater_url.as_deref(), Some("https://one.com"));
     }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -221,7 +221,7 @@ mod tests {
             always_trigger_updater: false,
             never_trigger_updater: true,
             use_updater_url: Some("https://two.com".into()),
-            local_scene: false
+            local_scene: false,
         };
 
         let merged = a.merge_with(&b);

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -425,9 +425,12 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
 
         match self.protocol.value() {
             Some(deeplink) => {
-                let open_new_instance = AppEnvironment::cmd_args().open_deeplink_in_new_instance;
+                let args = AppEnvironment::cmd_args();
+
+                let open_new_instance = args.open_deeplink_in_new_instance;
                 let any_is_running = self.is_any_instance_running().await?;
-                let is_local_scene = deeplink.has_true_value("local-scene");
+                let is_local_scene = deeplink.has_true_value("local-scene") || args.local_scene;
+
                 if !open_new_instance && any_is_running && !is_local_scene {
                     channel.send(Status::State {
                         step: Step::DeeplinkOpening,

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -427,7 +427,8 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
             Some(deeplink) => {
                 let open_new_instance = AppEnvironment::cmd_args().open_deeplink_in_new_instance;
                 let any_is_running = self.is_any_instance_running().await?;
-                if !open_new_instance && any_is_running {
+                let is_local_scene = deeplink.has_true_value("local-scene");
+                if !open_new_instance && any_is_running && !is_local_scene {
                     channel.send(Status::State {
                         step: Step::DeeplinkOpening,
                     })?;

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -531,7 +531,9 @@ impl InstallsHub {
                 )
             })?;
 
-        {
+        // local scene development instances are ignored and are not tracked as running instances
+        let has_local_scene_flag = AppEnvironment::cmd_args().local_scene;
+        if !has_local_scene_flag {
             let guard = self.running_instances.lock().await;
             guard.register_instance(child.id());
         }

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -531,9 +531,7 @@ impl InstallsHub {
                 )
             })?;
 
-        // local scene development instances are ignored and are not tracked as running instances
-        let has_local_scene_flag = AppEnvironment::cmd_args().local_scene;
-        if !has_local_scene_flag {
+        {
             let guard = self.running_instances.lock().await;
             guard.register_instance(child.id());
         }

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
 use std::result::Result;
+use std::sync::Mutex;
 use url::form_urlencoded;
 
 use log::{error, warn};

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -42,7 +42,7 @@ impl DeepLink {
 
         match parts.get(1) {
             Some(query) => {
-                let scheme = parts.get(0).unwrap_or(&"unknown");
+                let scheme = parts.first().unwrap_or(&"unknown");
                 log::info!("Deeplink scheme: {}", scheme);
 
                 let parsed = form_urlencoded::parse(query.as_bytes());

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Decentraland-Launcher"
-version = "1.5.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "dcl-launcher-core",
@@ -81,56 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -468,52 +418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,10 +657,9 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.5.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
- "clap",
  "deranged",
  "dirs 5.0.1",
  "fern",
@@ -782,6 +685,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
+ "url",
  "uuid",
  "windows-sys 0.59.0",
  "zip",
@@ -1999,12 +1903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,12 +2596,6 @@ name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -5053,12 +4945,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"


### PR DESCRIPTION
# Solution
Solves issue #140, instances that were launched with the local scene flag are excluded from deeplink handling logic

# Test Instruction

1. Install the PR's launcher and ensure auto-updater is disabled
2. Raplace latest build in the launcher working dir with the build from the PR https://github.com/decentraland/unity-explorer/pull/4877 
3. Open multiple instances with Creator hub, none of the instances should start to handle deeplink
4. Close all local scene development instances
5. Open client normally
6. Go to the decentraland website and click on a random event that teleports you to a destination
7. Launcher must open the selected deeplink normally without opening a new instance