### PR TITLE
chore: specify certain version 1.88.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.88.0
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - run: npm ci


### PR DESCRIPTION
# Why

This PR fixes the issue with new lint rules which arise on rust version updates. Certain rust version was specified to the build action to avoid CI interrupts 