### PR TITLE
chore: receive "open in new instance" arg from deeplink

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.9.5"
+version = "1.11.2"
 dependencies = [
  "anyhow",
  "deranged",

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -14,8 +14,8 @@ use time::OffsetDateTime;
 
 use tokio::sync::Mutex;
 
-use crate::environment::AppEnvironment;
 use crate::analytics::network_info::network_context;
+use crate::environment::AppEnvironment;
 
 use super::event::Event;
 use super::session::SessionId;

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -10,11 +10,12 @@ const LAUNCHER_ENVIRONMENT: Option<&str> = option_env!("LAUNCHER_ENVIRONMENT");
 
 const ARG_SKIP_ANALYTICS: &str = "skip-analytics";
 const ARG_FORCE_IN_MEMORY_ANALYTICS_QUEUE: &str = "force-in-memory-analytics-queue";
-const ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE: &str = "open-deeplink-in-new-instance";
 const ARG_ALWAYS_TRIGGER_UPDATER: &str = "always-trigger-updater";
 const ARG_NEVER_TRIGGER_UPDATER: &str = "never-trigger-updater";
 const ARG_USE_UPDATER_URL: &str = "use-updater-url";
-const ARG_LOCAL_SCENE: &str = "local-scene";
+
+pub const ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE: &str = "open-deeplink-in-new-instance";
+pub const ARG_LOCAL_SCENE: &str = "local-scene";
 
 #[derive(Debug)]
 pub enum LauncherEnvironment {

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -2,6 +2,7 @@ use crate::channel::EventChannel;
 use crate::deeplink_bridge::{
     PlaceDeeplinkError, PlaceDeeplinkResult, place_deeplink_and_wait_until_consumed,
 };
+use crate::environment::{ARG_LOCAL_SCENE, ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE};
 use crate::errors::{AttemptError, StepError, StepResultTyped};
 use crate::instances::RunningInstances;
 use crate::protocols::Protocol;
@@ -459,9 +460,10 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
             Some(deeplink) => {
                 let args = AppEnvironment::cmd_args();
 
-                let open_new_instance = args.open_deeplink_in_new_instance;
+                let open_new_instance = deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)
+                    || args.open_deeplink_in_new_instance;
                 let any_is_running = self.is_any_instance_running().await?;
-                let is_local_scene = deeplink.has_true_value("local-scene") || args.local_scene;
+                let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
 
                 if !open_new_instance && any_is_running && !is_local_scene {
                     channel.send(Status::State {

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -139,7 +139,9 @@ fn get_version_data() -> Result<Map<String, Value>> {
 
 fn get_version_data_or_empty() -> Map<String, Value> {
     get_version_data().unwrap_or_else(|_e| {
-        log::error!("Cannot get version data, fallback to new empty: File doesn't exist: version.json");
+        log::error!(
+            "Cannot get version data, fallback to new empty: File doesn't exist: version.json"
+        );
 
         Map::new()
     })


### PR DESCRIPTION
# Changes

Read the param from deeplink or from args

# Test

Use a deeplink with the param, for example `decentraland://?realm=boedo.dcl.eth&scene-console=true&open-deeplink-in-new-instance=true`, it should open new instance of explorer