### PR TITLE
feat: manual align version (named feat instead of fix to trigger auto-bump for minor version, because it was skipped due the error)

### DIFF
--- a/src-auto-auth/Cargo.toml
+++ b/src-auto-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "src-auto-auth"
-version = "1.11.2"
+version = "1.11.3"
 edition = "2024"
 
 [profile.dev]


### PR DESCRIPTION
Fixes CI error that caused due the unaligned version of new Cargo.toml