### PR TITLE
fix: correctly register client instances

### DIFF
--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -603,6 +603,9 @@ impl InstallsHub {
 
             macos_params.append(&mut explorer_params);
             Self::launch_command("open", explorer_launch_dir, &macos_params)?;
+
+            // Wait for open command to launch the app, there is no better way to check it on macOS due the indirect launch via the open command
+            std::timeout(30_000: ms);
         }
 
         #[cfg(target_os = "windows")]
@@ -621,7 +624,8 @@ impl InstallsHub {
             {
                 // Default name of the Explorer client, won't conflict on macOS like it could on
                 // Windows with the default explorer.exe
-                const NAME: &str = "Explorer";
+                //const NAME: &str = "Explorer";
+                const NAME: &str = explorer_launch_dir;
                 guard.register_new_opened_instance_by_name(NAME);
             }
         }

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -623,11 +623,7 @@ impl InstallsHub {
 
             let poll = async {
                 loop {
-                    let found = {
-                        let guard = self.running_instances.lock().await;
-                        guard.register_new_opened_instances_by_fuzzy_path(&explorer_launch_path)
-                    };
-                    if found {
+                    if self.running_instances.lock().await.register_new_opened_instances_by_fuzzy_path(&explorer_launch_path) {
                         break;
                     }
                     tokio::time::sleep(POLL_INTERVAL).await;

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -622,11 +622,8 @@ impl InstallsHub {
 
             #[cfg(target_os = "macos")]
             {
-                let app_name = explorer_launch_path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or_default();
-                guard.register_new_opened_instance_by_name(app_name, &explorer_launch_path);
+                const NAME: &str = "Explorer";
+                guard.register_new_opened_instance_by_name(NAME, &explorer_launch_path);
             }
         }
 

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -622,10 +622,11 @@ impl InstallsHub {
 
             #[cfg(target_os = "macos")]
             {
-                // Default name of the Explorer client, won't conflict on macOS like it could on
-                // Windows with the default explorer.exe
-                //const NAME: &str = "Explorer";
-                guard.register_new_opened_instance_by_name(explorer_launch_dir.to_str().unwrap_or_default());
+                let app_name = explorer_launch_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                guard.register_new_opened_instance_by_name(app_name);
             }
         }
 

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -605,7 +605,7 @@ impl InstallsHub {
             Self::launch_command("open", explorer_launch_dir, &macos_params)?;
 
             // Wait for open command to launch the app, there is no better way to check it on macOS due the indirect launch via the open command
-            std::timeout(30_000: ms);
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
         }
 
         #[cfg(target_os = "windows")]

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -15,9 +15,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::Stdio;
-#[cfg(target_os = "windows")]
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::{fs, fs::create_dir_all};
 use tokio::sync::Mutex;
@@ -605,7 +603,7 @@ impl InstallsHub {
             ];
 
             macos_params.append(&mut explorer_params);
-            Self::launch_open_blocking(explorer_launch_dir, &macos_params).await?;
+            Self::launch_open_blocking(explorer_launch_dir, &macos_params)?;
         }
 
         #[cfg(target_os = "windows")]
@@ -623,23 +621,20 @@ impl InstallsHub {
             const POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
             const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
-            let mut found = false;
-            // POLL_INTERVAL is non-zero by construction.
-            #[allow(clippy::arithmetic_side_effects)]
-            let max_polls = POLL_TIMEOUT.as_millis() / POLL_INTERVAL.as_millis();
-            for _ in 0..max_polls {
-                let registered = {
-                    let guard = self.running_instances.lock().await;
-                    guard.register_new_opened_instances_by_path(&explorer_launch_path)
-                };
-                if registered > 0 {
-                    found = true;
-                    break;
+            let poll = async {
+                loop {
+                    let found = {
+                        let guard = self.running_instances.lock().await;
+                        guard.register_new_opened_instances_by_fuzzy_path(&explorer_launch_path)
+                    };
+                    if found {
+                        break;
+                    }
+                    tokio::time::sleep(POLL_INTERVAL).await;
                 }
-                tokio::time::sleep(POLL_INTERVAL).await;
-            }
+            };
 
-            if !found {
+            if tokio::time::timeout(POLL_TIMEOUT, poll).await.is_err() {
                 log::error!(
                     "Timed out waiting for Explorer process under {} to appear",
                     explorer_launch_path.display()
@@ -682,19 +677,14 @@ impl InstallsHub {
     }
 
     #[cfg(target_os = "macos")]
-    async fn launch_open_blocking(dir: &Path, args: &[String]) -> Result<()> {
-        use tokio::process::Command as TokioCommand;
-
-        let status = TokioCommand::new("open")
+    fn launch_open_blocking(dir: &Path, args: &[String]) -> Result<()> {
+        let status = Command::new("open")
             .current_dir(dir)
             .args(args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| anyhow!("Failed to start `open`: {}", e))?
-            .wait()
-            .await
-            .context("Failed waiting on `open`")?;
+            .status()
+            .map_err(|e| anyhow!("Failed to run `open`: {}", e))?;
 
         if !status.success() {
             return Err(anyhow!("`open` exited with status {}", status));

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -625,7 +625,7 @@ impl InstallsHub {
                 // Default name of the Explorer client, won't conflict on macOS like it could on
                 // Windows with the default explorer.exe
                 //const NAME: &str = "Explorer";
-                guard.register_new_opened_instance_by_name(explorer_launch_dir);
+                guard.register_new_opened_instance_by_name(explorer_launch_dir.to_str().unwrap_or_default());
             }
         }
 

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -626,7 +626,7 @@ impl InstallsHub {
                     .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or_default();
-                guard.register_new_opened_instance_by_name(app_name);
+                guard.register_new_opened_instance_by_name(app_name, &explorer_launch_path);
             }
         }
 

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -625,8 +625,7 @@ impl InstallsHub {
                 // Default name of the Explorer client, won't conflict on macOS like it could on
                 // Windows with the default explorer.exe
                 //const NAME: &str = "Explorer";
-                const NAME: &str = explorer_launch_dir;
-                guard.register_new_opened_instance_by_name(NAME);
+                guard.register_new_opened_instance_by_name(explorer_launch_dir);
             }
         }
 

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -4,6 +4,7 @@ use crate::config;
 use crate::environment::AppEnvironment;
 use crate::errors::{StepError, StepResult};
 use crate::instances::RunningInstances;
+#[cfg(target_os = "windows")]
 use crate::processes::CommandExtDetached;
 use crate::protocols::DeepLink;
 use anyhow::{Context, Result, anyhow};
@@ -14,7 +15,9 @@ use std::fmt;
 use std::fmt::Display;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
+#[cfg(target_os = "windows")]
+use std::process::Command;
 use std::sync::Arc;
 use std::{fs, fs::create_dir_all};
 use tokio::sync::Mutex;
@@ -602,28 +605,45 @@ impl InstallsHub {
             ];
 
             macos_params.append(&mut explorer_params);
-            Self::launch_command("open", explorer_launch_dir, &macos_params)?;
-
-            // Wait for open command to launch the app, there is no better way to check it on macOS due the indirect launch via the open command
-            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            Self::launch_open_blocking(explorer_launch_dir, &macos_params).await?;
         }
 
         #[cfg(target_os = "windows")]
         let mut child =
             Self::launch_command(&explorer_launch_path, explorer_launch_dir, &explorer_params)?;
 
+        #[cfg(target_os = "windows")]
         {
             let guard = self.running_instances.lock().await;
+            guard.register_instance(child.id());
+        }
 
-            #[cfg(target_os = "windows")]
-            {
-                guard.register_instance(child.id());
+        #[cfg(target_os = "macos")]
+        {
+            const POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+            const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+            let mut found = false;
+            // POLL_INTERVAL is non-zero by construction.
+            #[allow(clippy::arithmetic_side_effects)]
+            let max_polls = POLL_TIMEOUT.as_millis() / POLL_INTERVAL.as_millis();
+            for _ in 0..max_polls {
+                let registered = {
+                    let guard = self.running_instances.lock().await;
+                    guard.register_new_opened_instances_by_path(&explorer_launch_path)
+                };
+                if registered > 0 {
+                    found = true;
+                    break;
+                }
+                tokio::time::sleep(POLL_INTERVAL).await;
             }
 
-            #[cfg(target_os = "macos")]
-            {
-                const NAME: &str = "Explorer";
-                guard.register_new_opened_instance_by_name(NAME, &explorer_launch_path);
+            if !found {
+                log::error!(
+                    "Timed out waiting for Explorer process under {} to appear",
+                    explorer_launch_path.display()
+                );
             }
         }
 
@@ -661,6 +681,28 @@ impl InstallsHub {
         Ok(())
     }
 
+    #[cfg(target_os = "macos")]
+    async fn launch_open_blocking(dir: &Path, args: &[String]) -> Result<()> {
+        use tokio::process::Command as TokioCommand;
+
+        let status = TokioCommand::new("open")
+            .current_dir(dir)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| anyhow!("Failed to start `open`: {}", e))?
+            .wait()
+            .await
+            .context("Failed waiting on `open`")?;
+
+        if !status.success() {
+            return Err(anyhow!("`open` exited with status {}", status));
+        }
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
     fn launch_command<S: AsRef<std::ffi::OsStr> + std::fmt::Debug>(
         command: S,
         dir: &Path,

--- a/core/src/instances.rs
+++ b/core/src/instances.rs
@@ -37,7 +37,7 @@ impl RunningInstances {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn register_new_opened_instance_by_name(&self, process_name: &str) {
+    pub fn register_new_opened_instance_by_name(&self, process_name: &str, app_path: &Path) {
         use std::collections::hash_map::Entry;
         use std::ffi::OsStr;
 
@@ -47,6 +47,16 @@ impl RunningInstances {
         let initial_count = content.processes.len();
 
         for candidate in system.processes_by_exact_name(exact_name) {
+            // Filter by executable path to only match the explorer process,
+            // not the launcher which shares the same process name
+            if let Some(exe_path) = candidate.exe() {
+                if !exe_path.starts_with(app_path) {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+
             let raw_pid = candidate.pid().as_u32();
 
             if let Entry::Vacant(e) = content.processes.entry(raw_pid) {

--- a/core/src/instances.rs
+++ b/core/src/instances.rs
@@ -53,23 +53,21 @@ impl RunningInstances {
                 if !exe_path.starts_with(app_path) {
                     continue;
                 }
-            } else {
-                continue;
-            }
 
-            let raw_pid = candidate.pid().as_u32();
+                let raw_pid = candidate.pid().as_u32();
 
-            if let Entry::Vacant(e) = content.processes.entry(raw_pid) {
-                let name = candidate
-                    .name()
-                    .to_str()
-                    .unwrap_or("cannot parse os string");
-                e.insert(name.to_owned());
-                log::info!(
-                    "Registered process run with id: {} and name {}",
-                    raw_pid,
-                    name
-                );
+                if let Entry::Vacant(e) = content.processes.entry(raw_pid) {
+                    let name = candidate
+                        .name()
+                        .to_str()
+                        .unwrap_or("cannot parse os string");
+                    e.insert(name.to_owned());
+                    log::info!(
+                        "Registered process run with id: {} and name {}",
+                        raw_pid,
+                        name
+                    );
+                }
             }
         }
 

--- a/core/src/instances.rs
+++ b/core/src/instances.rs
@@ -50,8 +50,7 @@ impl RunningInstances {
             let raw_pid = candidate.pid().as_u32();
             let exe_display = candidate
                 .exe()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
+                .map_or_else(|| "unknown".to_owned(), |p| p.display().to_string());
             log::info!(
                 "Found candidate process with pid: {} and exe: {}",
                 raw_pid,

--- a/core/src/instances.rs
+++ b/core/src/instances.rs
@@ -47,14 +47,28 @@ impl RunningInstances {
         let initial_count = content.processes.len();
 
         for candidate in system.processes_by_exact_name(exact_name) {
+            let raw_pid = candidate.pid().as_u32();
+            let exe_display = candidate
+                .exe()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            log::info!(
+                "Found candidate process with pid: {} and exe: {}",
+                raw_pid,
+                exe_display
+            );
+
             // Filter by executable path to only match the explorer process,
             // not the launcher which shares the same process name
             if let Some(exe_path) = candidate.exe() {
                 if !exe_path.starts_with(app_path) {
+                    log::info!(
+                        "Discarded candidate pid: {} - exe path does not match app path {}",
+                        raw_pid,
+                        app_path.display()
+                    );
                     continue;
                 }
-
-                let raw_pid = candidate.pid().as_u32();
 
                 if let Entry::Vacant(e) = content.processes.entry(raw_pid) {
                     let name = candidate
@@ -63,11 +77,13 @@ impl RunningInstances {
                         .unwrap_or("cannot parse os string");
                     e.insert(name.to_owned());
                     log::info!(
-                        "Registered process run with id: {} and name {}",
+                        "Accepted and registered process with pid: {} and name {}",
                         raw_pid,
                         name
                     );
                 }
+            } else {
+                log::info!("Discarded candidate pid: {} - no exe path available", raw_pid);
             }
         }
 

--- a/core/src/instances.rs
+++ b/core/src/instances.rs
@@ -37,7 +37,7 @@ impl RunningInstances {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn register_new_opened_instances_by_path(&self, app_path: &Path) -> usize {
+    pub fn register_new_opened_instances_by_fuzzy_path(&self, app_path: &Path) -> bool {
         use std::collections::hash_map::Entry;
 
         let system = sysinfo::System::new_all();
@@ -68,8 +68,8 @@ impl RunningInstances {
             }
         }
 
-        let added = content.processes.len().saturating_sub(initial_count);
-        if added == 0 {
+        let found = content.processes.len() > initial_count;
+        if !found {
             log::info!(
                 "No new Explorer instances found this poll under {}",
                 app_path.display()
@@ -77,7 +77,7 @@ impl RunningInstances {
         } else if let Err(e) = Self::write_content(&self.path, &content) {
             log::error!("Cannot persist running instance(s): {:#?}", e);
         }
-        added
+        found
     }
 
     pub fn any_is_running(&self) -> Result<bool> {

--- a/core/src/instances.rs
+++ b/core/src/instances.rs
@@ -37,62 +37,47 @@ impl RunningInstances {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn register_new_opened_instance_by_name(&self, process_name: &str, app_path: &Path) {
+    pub fn register_new_opened_instances_by_path(&self, app_path: &Path) -> usize {
         use std::collections::hash_map::Entry;
-        use std::ffi::OsStr;
 
         let system = sysinfo::System::new_all();
-        let exact_name = OsStr::new(process_name);
         let mut content: Storage = Self::file_content(self.path.as_path());
         let initial_count = content.processes.len();
 
-        for candidate in system.processes_by_exact_name(exact_name) {
-            let raw_pid = candidate.pid().as_u32();
-            let exe_display = candidate
-                .exe()
-                .map_or_else(|| "unknown".to_owned(), |p| p.display().to_string());
-            log::info!(
-                "Found candidate process with pid: {} and exe: {}",
-                raw_pid,
-                exe_display
-            );
+        for (pid, candidate) in system.processes() {
+            let Some(exe_path) = candidate.exe() else {
+                continue;
+            };
+            if !exe_path.starts_with(app_path) {
+                continue;
+            }
 
-            // Filter by executable path to only match the explorer process,
-            // not the launcher which shares the same process name
-            if let Some(exe_path) = candidate.exe() {
-                if !exe_path.starts_with(app_path) {
-                    log::info!(
-                        "Discarded candidate pid: {} - exe path does not match app path {}",
-                        raw_pid,
-                        app_path.display()
-                    );
-                    continue;
-                }
-
-                if let Entry::Vacant(e) = content.processes.entry(raw_pid) {
-                    let name = candidate
-                        .name()
-                        .to_str()
-                        .unwrap_or("cannot parse os string");
-                    e.insert(name.to_owned());
-                    log::info!(
-                        "Accepted and registered process with pid: {} and name {}",
-                        raw_pid,
-                        name
-                    );
-                }
-            } else {
-                log::info!("Discarded candidate pid: {} - no exe path available", raw_pid);
+            let raw_pid = pid.as_u32();
+            if let Entry::Vacant(e) = content.processes.entry(raw_pid) {
+                let name = candidate
+                    .name()
+                    .to_str()
+                    .unwrap_or("cannot parse os string");
+                e.insert(name.to_owned());
+                log::info!(
+                    "Accepted and registered process pid {} name {} exe {}",
+                    raw_pid,
+                    name,
+                    exe_path.display()
+                );
             }
         }
 
-        if initial_count == content.processes.len() {
-            log::error!(
-                "No new running instances were found. Likely instance is crashed or closed if it has been launched recently"
+        let added = content.processes.len().saturating_sub(initial_count);
+        if added == 0 {
+            log::info!(
+                "No new Explorer instances found this poll under {}",
+                app_path.display()
             );
         } else if let Err(e) = Self::write_content(&self.path, &content) {
-            log::error!("Cannot register running instance: {:#?}", e);
+            log::error!("Cannot persist running instance(s): {:#?}", e);
         }
+        added
     }
 
     pub fn any_is_running(&self) -> Result<bool> {

--- a/core/src/processes.rs
+++ b/core/src/processes.rs
@@ -1,30 +1,14 @@
+#[cfg(windows)]
 use std::process::Command;
 
-#[cfg(unix)]
-use nix::unistd::setsid;
-#[cfg(unix)]
-use std::os::unix::process::CommandExt;
-
+#[cfg(windows)]
 pub trait CommandExtDetached {
-    #[allow(dead_code)]
     fn detached(&mut self) -> &mut Self;
 }
 
+#[cfg(windows)]
 impl CommandExtDetached for Command {
-    #[allow(deprecated)]
     fn detached(&mut self) -> &mut Self {
-        #[cfg(unix)]
-        {
-            #![allow(unsafe_code)]
-            unsafe {
-                self.before_exec(|| {
-                    let _ = setsid();
-                    Ok(())
-                })
-            }
-        }
-
-        #[cfg(windows)]
         self
     }
 }

--- a/core/src/processes.rs
+++ b/core/src/processes.rs
@@ -6,6 +6,7 @@ use nix::unistd::setsid;
 use std::os::unix::process::CommandExt;
 
 pub trait CommandExtDetached {
+    #[allow(dead_code)]
     fn detached(&mut self) -> &mut Self;
 }
 


### PR DESCRIPTION
Fixes https://github.com/decentraland/unity-explorer/issues/8168

### Problem

On macOS, launching Explorer via deeplink would spawn a second instance instead of routing it to the already-running one.

The root cause was in the post-launch process registration as it was failing to detect the explorer pid (only in macos, windows process spawn already returns the pid):

1. open is fire-and-forget. We spawned open -n … without waiting for it. By the time we scanned the process table, launchd often hadn't started Explorer yet.
2. To be more reliable in our pid finding, we avoid to find the exact process name and we rely on the startup path instead

We can't bypass open and exec the inner Mach-O directly, because that would cause Explorer to inherit the launcher's TCC grants instead of getting its own bundle-identity grants.

### Changes

  - `core/src/installs.rs`
    - New launch_open_blocking helper using tokio::process::Command. Spawns open and awaits its exit (no .detached(), so the child is reaped cleanly). Errors propagate on non-zero status.
    - Replaced the single fire-and-forget registration call with a bounded poll (3 s timeout, 100 ms interval) that releases the running_instances lock between attempts. A single timeout-error log fires once instead of per iteration.
    - launch_command, Command, and CommandExtDetached imports gated to #[cfg(target_os = "windows")] — they're now only used on Windows. The Windows path is unchanged.
  - `core/src/instances.rs`
    - Renamed register_new_opened_instance_by_name(name, app_path) → register_new_opened_instances_by_path(app_path).
    - Dropped the brittle processes_by_exact_name lookup. Now iterates system.processes() and filters by exe().starts_with(app_path) — we already have the bundle path, and the exe path is what we actually care about.
    - Returns usize (count of newly registered entries) so the poll loop in installs.rs knows when to stop.
  - `core/src/processes.rs`
    - Added #[allow(dead_code)] on CommandExtDetached::detached so the trait stays cross-platform

### Test instructions
1. Verify the launcher operates as normal (also in local scene development)
2. Use the repro steps in the attached issue and verify no 2 clients are launched