### PR TITLE
chore: update macOS binary and process name to Decentraland

### DIFF
--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -382,7 +382,7 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
 
     #[cfg(target_os = "macos")]
     {
-        const EXPLORER_MAC_BIN_PATH: &str = "Decentraland.app/Contents/MacOS/Explorer";
+        const EXPLORER_MAC_BIN_PATH: &str = "Decentraland.app/Contents/MacOS/Decentraland";
 
         let from = &branch_path.join("build");
         let to = &branch_path;
@@ -619,9 +619,9 @@ impl InstallsHub {
 
             #[cfg(target_os = "macos")]
             {
-                // Default name of the Explorer client, won't conflict on macOS like it could on
-                // Windows with the default explorer.exe
-                const NAME: &str = "Explorer";
+                // Default name of the Explorer client after the productName rename in
+                // decentraland/unity-explorer#8207.
+                const NAME: &str = "Decentraland";
                 guard.register_new_opened_instance_by_name(NAME);
             }
         }


### PR DESCRIPTION
## Summary
- Aligns launcher-rust with the Unity `productName` rename in [decentraland/unity-explorer#8207](https://github.com/decentraland/unity-explorer/pull/8207), which changes the product name from `Explorer` to `Decentraland`.
- Updates the macOS post-install chmod path from `Decentraland.app/Contents/MacOS/Explorer` to `.../MacOS/Decentraland` so the installed binary gets marked executable.
- Updates the macOS running-instance tracking name from `Explorer` to `Decentraland` so the launcher correctly finds the running process after the rename.
- Windows is unaffected — `EXPLORER_WIN_BIN_PATH` was already `Decentraland.exe`.

## Coordination
- **Must land after unity-explorer#8207 ships in a build.** If this PR is released against older explorer builds, macOS installs will break: the binary won't be chmod'd and running-instance tracking won't find the process.
- Recommend gating the release of this change behind the first explorer build that contains the productName rename.

## Test plan
- [ ] CI builds green
- [ ] Manually verify on macOS against a build from unity-explorer#8207: install completes, binary is executable, launcher detects the running Decentraland process
- [ ] Manually verify on Windows that launching still works unchanged