### PR TITLE
feat: read anon_user_id from installer and forward to explorer

### DIFF
--- a/core/src/analytics.rs
+++ b/core/src/analytics.rs
@@ -80,11 +80,11 @@ impl Analytics {
         }
     }
 
-    /// Set the campaign anonymous user ID for attribution tracking.
-    /// Once set, all subsequent events will include this ID.
-    pub fn set_campaign_anon_user_id(&mut self, id: &str) {
-        if let Self::Client(client) = self {
-            client.set_campaign_anon_user_id(id.to_owned());
+    #[must_use]
+    pub fn with_campaign_anon_user_id(self, id: &str) -> Self {
+        match self {
+            Self::Client(client) => Self::Client(client.with_campaign_anon_user_id(id.to_owned())),
+            null @ Self::Null(_) => null,
         }
     }
 

--- a/core/src/analytics.rs
+++ b/core/src/analytics.rs
@@ -22,7 +22,6 @@ pub struct CreateArgs {
     anonymous_id: String,
     os: String,
     launcher_version: String,
-    campaign_anon_user_id: Option<String>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -32,7 +31,7 @@ pub enum Analytics {
 }
 
 impl Analytics {
-    pub fn new_from_env(campaign_anon_user_id: Option<String>) -> Self {
+    pub fn new_from_env() -> Self {
         if AppEnvironment::cmd_args().skip_analytics {
             info!("SEGMENT_API_KEY running with --skip-analytics, segment is not available");
             return Self::new(None);
@@ -53,7 +52,6 @@ impl Analytics {
                     anonymous_id,
                     os,
                     launcher_version,
-                    campaign_anon_user_id,
                 };
                 Some(args)
             }
@@ -75,11 +73,18 @@ impl Analytics {
                     a.anonymous_id,
                     a.os,
                     a.launcher_version,
-                    a.campaign_anon_user_id,
                 );
                 Self::Client(client)
             }
             None => Self::Null(NullClient::new()),
+        }
+    }
+
+    /// Set the campaign anonymous user ID for attribution tracking.
+    /// Once set, all subsequent events will include this ID.
+    pub fn set_campaign_anon_user_id(&mut self, id: &str) {
+        if let Self::Client(client) = self {
+            client.set_campaign_anon_user_id(id.to_owned());
         }
     }
 

--- a/core/src/analytics.rs
+++ b/core/src/analytics.rs
@@ -22,6 +22,7 @@ pub struct CreateArgs {
     anonymous_id: String,
     os: String,
     launcher_version: String,
+    campaign_anon_user_id: Option<String>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -31,7 +32,7 @@ pub enum Analytics {
 }
 
 impl Analytics {
-    pub fn new_from_env() -> Self {
+    pub fn new_from_env(campaign_anon_user_id: Option<String>) -> Self {
         if AppEnvironment::cmd_args().skip_analytics {
             info!("SEGMENT_API_KEY running with --skip-analytics, segment is not available");
             return Self::new(None);
@@ -52,6 +53,7 @@ impl Analytics {
                     anonymous_id,
                     os,
                     launcher_version,
+                    campaign_anon_user_id,
                 };
                 Some(args)
             }
@@ -68,8 +70,13 @@ impl Analytics {
     pub fn new(args: Option<CreateArgs>) -> Self {
         match args {
             Some(a) => {
-                let client =
-                    AnalyticsClient::new(a.write_key, a.anonymous_id, a.os, a.launcher_version);
+                let client = AnalyticsClient::new(
+                    a.write_key,
+                    a.anonymous_id,
+                    a.os,
+                    a.launcher_version,
+                    a.campaign_anon_user_id,
+                );
                 Self::Client(client)
             }
             None => Self::Null(NullClient::new()),

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -26,6 +26,7 @@ pub struct AnalyticsClient {
     anonymous_id: String,
     os: String,
     launcher_version: String,
+    campaign_anon_user_id: Option<String>,
     session_id: SessionId,
     batcher: QueuedBatcher,
     send_daemon: AnalyticsEventSendDaemon<HttpClient>,
@@ -37,6 +38,7 @@ impl AnalyticsClient {
         anonymous_id: String,
         os: String,
         launcher_version: String,
+        campaign_anon_user_id: Option<String>,
     ) -> Self {
         let queue = new_event_queue();
         let queue = Arc::new(Mutex::new(queue));
@@ -54,6 +56,7 @@ impl AnalyticsClient {
             anonymous_id,
             os,
             launcher_version,
+            campaign_anon_user_id,
             session_id,
             batcher,
             send_daemon,
@@ -71,6 +74,13 @@ impl AnalyticsClient {
             Value::String(self.session_id.value().to_owned()),
         );
         properties.insert("appId".to_owned(), Value::String(APP_ID.to_owned()));
+
+        if let Some(anon_id) = &self.campaign_anon_user_id {
+            properties.insert(
+                "campaignAnonUserId".to_owned(),
+                Value::String(anon_id.clone()),
+            );
+        }
 
         let user = User::AnonymousId {
             anonymous_id: self.anonymous_id.clone(),

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -62,8 +62,9 @@ impl AnalyticsClient {
         }
     }
 
-    pub fn set_campaign_anon_user_id(&mut self, id: String) {
+    pub fn with_campaign_anon_user_id(mut self, id: String) -> Self {
         self.campaign_anon_user_id = Some(id);
+        self
     }
 
     async fn track(&mut self, event: String, mut properties: Map<String, Value>) -> Result<()> {

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -77,7 +77,7 @@ impl AnalyticsClient {
 
         if let Some(anon_id) = &self.campaign_anon_user_id {
             properties.insert(
-                "campaignAnonUserId".to_owned(),
+                "campaign_anon_user_id".to_owned(),
                 Value::String(anon_id.clone()),
             );
         }

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -38,7 +38,6 @@ impl AnalyticsClient {
         anonymous_id: String,
         os: String,
         launcher_version: String,
-        campaign_anon_user_id: Option<String>,
     ) -> Self {
         let queue = new_event_queue();
         let queue = Arc::new(Mutex::new(queue));
@@ -56,11 +55,15 @@ impl AnalyticsClient {
             anonymous_id,
             os,
             launcher_version,
-            campaign_anon_user_id,
+            campaign_anon_user_id: None,
             session_id,
             batcher,
             send_daemon,
         }
+    }
+
+    pub fn set_campaign_anon_user_id(&mut self, id: String) {
+        self.campaign_anon_user_id = Some(id);
     }
 
     async fn track(&mut self, event: String, mut properties: Map<String, Value>) -> Result<()> {

--- a/core/src/analytics/event.rs
+++ b/core/src/analytics/event.rs
@@ -74,6 +74,9 @@ pub enum Event {
     RETRY_FLOW_BUTTON_CLICK {
         version: String,
     },
+    CAMPAIGN_ATTRIBUTION_DETECTED {
+        anon_user_id: String,
+    },
 }
 
 impl Display for Event {
@@ -104,6 +107,7 @@ impl Display for Event {
                 Event::LAUNCHER_UPDATE_DOWNLOADED { .. } => "Launcher Update Downloaded",
                 Event::FLOW_ATTEMPT_ERROR { .. } => "Launcher Attempt Error",
                 Event::RETRY_FLOW_BUTTON_CLICK { .. } => "Retry Flow Button Click",
+                Event::CAMPAIGN_ATTRIBUTION_DETECTED { .. } => "Campaign Attribution Detected",
             }
         )
     }

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use crate::analytics::Analytics;
 use crate::analytics::event::Event;
 use crate::auto_auth::AutoAuth;
+use crate::config;
 use crate::flow::{LaunchFlow, LaunchFlowState};
 use crate::installs;
 use crate::instances::RunningInstances;
@@ -31,12 +32,31 @@ impl AppState {
 
         Monitoring::try_setup_sentry().context("Cannot setup monitoring")?;
 
-        let mut analytics = analytics::Analytics::new_from_env();
+        // Run auto-auth BEFORE analytics init so that campaign_anon_user_id is
+        // available in config.json for the analytics client constructor.
+        AutoAuth::try_obtain_auth_token();
+        #[cfg(target_os = "macos")]
+        AutoAuth::try_install_to_app_dir_if_from_dmg();
+
+        let campaign_anon_user_id = config::campaign_anon_user_id();
+
+        let mut analytics =
+            analytics::Analytics::new_from_env(campaign_anon_user_id.clone());
         analytics
             .track_and_flush_silent(Event::LAUNCHER_OPEN {
                 version: utils::app_version().to_owned(),
             })
             .await;
+
+        // Fire CAMPAIGN_ATTRIBUTION_DETECTED if a campaign anon_user_id is present
+        if let Some(anon_id) = &campaign_anon_user_id {
+            info!("Firing Campaign Attribution Detected event for anon_user_id: {anon_id}");
+            analytics
+                .track_and_flush_silent(Event::CAMPAIGN_ATTRIBUTION_DETECTED {
+                    anon_user_id: anon_id.clone(),
+                })
+                .await;
+        }
 
         let analytics = Arc::new(Mutex::new(analytics));
         let running_instances = Arc::new(Mutex::new(RunningInstances::default()));
@@ -44,10 +64,6 @@ impl AppState {
             analytics.clone(),
             running_instances.clone(),
         )));
-
-        AutoAuth::try_obtain_auth_token();
-        #[cfg(target_os = "macos")]
-        AutoAuth::try_install_to_app_dir_if_from_dmg();
 
         let flow = LaunchFlow::new(installs_hub, analytics.clone(), running_instances);
         let flow_state = LaunchFlowState::default();

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -48,14 +48,17 @@ impl AppState {
             })
             .await;
 
-        // Fire CAMPAIGN_ATTRIBUTION_DETECTED if a campaign anon_user_id is present
+        // Fire CAMPAIGN_ATTRIBUTION_DETECTED once per campaign attribution
         if let Some(anon_id) = &campaign_anon_user_id {
-            info!("Firing Campaign Attribution Detected event for anon_user_id: {anon_id}");
-            analytics
-                .track_and_flush_silent(Event::CAMPAIGN_ATTRIBUTION_DETECTED {
-                    anon_user_id: anon_id.clone(),
-                })
-                .await;
+            if !config::campaign_attribution_reported() {
+                info!("Firing Campaign Attribution Detected event");
+                analytics
+                    .track_and_flush_silent(Event::CAMPAIGN_ATTRIBUTION_DETECTED {
+                        anon_user_id: anon_id.clone(),
+                    })
+                    .await;
+                config::mark_campaign_attribution_reported();
+            }
         }
 
         let analytics = Arc::new(Mutex::new(analytics));

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -32,27 +32,33 @@ impl AppState {
 
         Monitoring::try_setup_sentry().context("Cannot setup monitoring")?;
 
-        // Run auto-auth BEFORE analytics init so that campaign_anon_user_id is
-        // available in config.json for the analytics client constructor.
         AutoAuth::try_obtain_auth_token();
         #[cfg(target_os = "macos")]
         AutoAuth::try_install_to_app_dir_if_from_dmg();
 
-        let campaign_anon_user_id = config::campaign_anon_user_id();
+        let mut analytics = analytics::Analytics::new_from_env();
 
-        let mut analytics =
-            analytics::Analytics::new_from_env(campaign_anon_user_id.clone());
+        // Attach campaign anon_user_id if present — stamps all subsequent events
+        let campaign_anon_user_id = config::campaign_anon_user_id();
+        if let Some(ref anon_id) = campaign_anon_user_id {
+            analytics.set_campaign_anon_user_id(anon_id);
+        }
+
         analytics
             .track_and_flush_silent(Event::LAUNCHER_OPEN {
                 version: utils::app_version().to_owned(),
             })
             .await;
 
-        // Fire CAMPAIGN_ATTRIBUTION_DETECTED once per campaign attribution.
-        // Mark before sending (at-most-once) to avoid duplicates on crash.
+        // Fire CAMPAIGN_ATTRIBUTION_DETECTED once per install.
+        // Uses a marker file (not config) to track at-most-once delivery.
         if let Some(anon_id) = &campaign_anon_user_id {
-            if !config::campaign_attribution_reported() {
-                config::mark_campaign_attribution_reported();
+            let marker = installs::campaign_attribution_reported_path();
+            if !marker.exists() {
+                // Write marker before sending (at-most-once) to avoid duplicates on crash
+                if let Err(e) = std::fs::write(&marker, "") {
+                    log::warn!("Cannot write attribution marker: {e}");
+                }
                 info!("Firing Campaign Attribution Detected event");
                 analytics
                     .track_and_flush_silent(Event::CAMPAIGN_ATTRIBUTION_DETECTED {

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -2,14 +2,16 @@ use anyhow::{Context, Result};
 
 use crate::analytics::Analytics;
 use crate::analytics::event::Event;
-use crate::auto_auth::AutoAuth;
-use crate::config;
+use crate::auto_auth::campaign_anon_user_id_storage::CampaignAnonUserIdStorage;
+use crate::auto_auth::campaign_attribution_marker::CampaignAttributionMarker;
 use crate::flow::{LaunchFlow, LaunchFlowState};
 use crate::installs;
 use crate::instances::RunningInstances;
 use crate::monitoring::Monitoring;
 use crate::protocols::Protocol;
 use crate::{analytics, logs, utils};
+#[cfg(target_os = "macos")]
+use crate::auto_auth::AutoAuth;
 use log::{error, info};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -32,17 +34,21 @@ impl AppState {
 
         Monitoring::try_setup_sentry().context("Cannot setup monitoring")?;
 
-        AutoAuth::try_obtain_auth_token();
         #[cfg(target_os = "macos")]
-        AutoAuth::try_install_to_app_dir_if_from_dmg();
-
-        let mut analytics = analytics::Analytics::new_from_env();
-
-        // Attach campaign anon_user_id if present — stamps all subsequent events
-        let campaign_anon_user_id = config::campaign_anon_user_id();
-        if let Some(ref anon_id) = campaign_anon_user_id {
-            analytics.set_campaign_anon_user_id(anon_id);
+        {
+            AutoAuth::try_obtain_auth_token();
+            AutoAuth::try_install_to_app_dir_if_from_dmg();
         }
+
+        let campaign_anon_user_id = CampaignAnonUserIdStorage::read();
+
+        let mut analytics = {
+            let analytics = analytics::Analytics::new_from_env();
+            match &campaign_anon_user_id {
+                Some(id) => analytics.with_campaign_anon_user_id(id.as_str()),
+                None => analytics,
+            }
+        };
 
         analytics
             .track_and_flush_silent(Event::LAUNCHER_OPEN {
@@ -50,19 +56,16 @@ impl AppState {
             })
             .await;
 
-        // Fire CAMPAIGN_ATTRIBUTION_DETECTED once per install.
-        // Uses a marker file (not config) to track at-most-once delivery.
         if let Some(anon_id) = &campaign_anon_user_id {
-            let marker = installs::campaign_attribution_reported_path();
-            if !marker.exists() {
-                // Write marker before sending (at-most-once) to avoid duplicates on crash
-                if let Err(e) = std::fs::write(&marker, "") {
+            if !CampaignAttributionMarker::is_reported() {
+                // Mark before sending (at-most-once) to avoid duplicates on crash
+                if let Err(e) = CampaignAttributionMarker::mark_reported() {
                     log::warn!("Cannot write attribution marker: {e}");
                 }
                 info!("Firing Campaign Attribution Detected event");
                 analytics
                     .track_and_flush_silent(Event::CAMPAIGN_ATTRIBUTION_DETECTED {
-                        anon_user_id: anon_id.clone(),
+                        anon_user_id: anon_id.as_str().to_owned(),
                     })
                     .await;
             }

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -48,16 +48,17 @@ impl AppState {
             })
             .await;
 
-        // Fire CAMPAIGN_ATTRIBUTION_DETECTED once per campaign attribution
+        // Fire CAMPAIGN_ATTRIBUTION_DETECTED once per campaign attribution.
+        // Mark before sending (at-most-once) to avoid duplicates on crash.
         if let Some(anon_id) = &campaign_anon_user_id {
             if !config::campaign_attribution_reported() {
+                config::mark_campaign_attribution_reported();
                 info!("Firing Campaign Attribution Detected event");
                 analytics
                     .track_and_flush_silent(Event::CAMPAIGN_ATTRIBUTION_DETECTED {
                         anon_user_id: anon_id.clone(),
                     })
                     .await;
-                config::mark_campaign_attribution_reported();
             }
         }
 

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -8,11 +8,59 @@ use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use auth_token_storage::AuthTokenStorage;
 
-/// Data extracted from the installer's download origin (xattr URLs on macOS,
-/// Zone.Identifier on Windows).
+use anon_user_id::AnonUserId;
+
+/// Data extracted from a download URL — auth token and campaign anonymous user ID.
+///
+/// Both fields are parsed independently from the same URL via `from_url()`,
+/// avoiding ordering or collision issues between the two.
 pub struct DownloadOriginData {
     pub auth_token: Option<String>,
-    pub campaign_anon_user_id: Option<String>,
+    pub campaign_anon_user_id: Option<AnonUserId>,
+}
+
+impl DownloadOriginData {
+    /// Extract both auth token and `anon_user_id` from a single URL.
+    ///
+    /// The auth token is matched by UUID regex on any query param value (except
+    /// `anon_user_id`) or path segment. The `anon_user_id` is matched by key name.
+    pub fn from_url(url_str: &str) -> Result<Self> {
+        let url = url::Url::parse(url_str)?;
+
+        let re = regex::Regex::new(
+            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        )?;
+
+        // Extract auth token from query params (skip anon_user_id key) or path segments
+        let mut auth_token: Option<String> = None;
+
+        for (key, value) in url.query_pairs() {
+            if key == "anon_user_id" {
+                continue;
+            }
+            if re.is_match(&value) {
+                auth_token = Some(value.to_string());
+                break;
+            }
+        }
+
+        if auth_token.is_none() {
+            if let Some(segments) = url.path_segments() {
+                auth_token = segments
+                    .filter(|s| re.is_match(s))
+                    .map(ToString::to_string)
+                    .next();
+            }
+        }
+
+        // Extract anon_user_id by key name (validated by AnonUserId::from_url)
+        let campaign_anon_user_id = AnonUserId::from_url(url_str);
+
+        Ok(Self {
+            auth_token,
+            campaign_anon_user_id,
+        })
+    }
 }
 
 pub struct AutoAuth {}
@@ -60,7 +108,7 @@ impl AutoAuth {
                 if !has_anon_id {
                     if let Some(ref anon_id) = origin.campaign_anon_user_id {
                         log::info!("Campaign anon_user_id obtained from DMG origin");
-                        crate::config::write_campaign_anon_user_id(anon_id);
+                        crate::config::write_campaign_anon_user_id(anon_id.as_str());
                     }
                 }
             }
@@ -107,7 +155,6 @@ impl AutoAuth {
             dest_path.display()
         );
 
-        // Use Apple's ditto, safest and signature-preserving
         let status = std::process::Command::new("ditto")
             .arg(&app_bundle)
             .arg(&dest_path)
@@ -158,36 +205,28 @@ impl AutoAuth {
             return Err(anyhow!("Dmg does not have where from data"));
         };
 
-        let mut found_token: Option<String> = None;
-        let mut found_anon_user_id: Option<String> = None;
+        let mut result = DownloadOriginData {
+            auth_token: None,
+            campaign_anon_user_id: None,
+        };
 
         for attr in &where_from {
-            // Extract auth token
-            if found_token.is_none() {
-                match token_from_url(attr) {
-                    Ok(token) => {
-                        if token.is_some() {
-                            found_token = token;
-                        }
+            match DownloadOriginData::from_url(attr) {
+                Ok(parsed) => {
+                    if result.auth_token.is_none() {
+                        result.auth_token = parsed.auth_token;
                     }
-                    Err(e) => {
-                        log::error!("Cannot read token from url '{}' due: {}", attr, e);
+                    if result.campaign_anon_user_id.is_none() {
+                        result.campaign_anon_user_id = parsed.campaign_anon_user_id;
                     }
                 }
-            }
-
-            // Extract anon_user_id (independently)
-            if found_anon_user_id.is_none() {
-                if let Some(anon_id) = anon_user_id::anon_user_id_from_url(attr) {
-                    found_anon_user_id = Some(anon_id);
+                Err(e) => {
+                    log::error!("Cannot parse url '{}': {}", attr, e);
                 }
             }
         }
 
-        Ok(DownloadOriginData {
-            auth_token: found_token,
-            campaign_anon_user_id: found_anon_user_id,
-        })
+        Ok(result)
     }
 }
 
@@ -206,32 +245,6 @@ fn app_bundle_from_exe_path(exe_path: &Path) -> std::io::Result<PathBuf> {
     ))
 }
 
-pub fn token_from_url(url_str: &str) -> Result<Option<String>> {
-    let url = url::Url::parse(url_str)?;
-
-    // Regex for token find
-    let re = regex::Regex::new(
-        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-    )?;
-
-    // Search in params — skip anon_user_id to avoid treating it as an auth token
-    for (key, value) in url.query_pairs() {
-        if key == "anon_user_id" {
-            continue;
-        }
-        if re.is_match(&value) {
-            return Ok(Some(value.to_string()));
-        }
-    }
-
-    // Split into path segments e.g. "391a85da-a3bb-49e2-a45e-96c740c38424"
-    let mut segments = url
-        .path_segments()
-        .ok_or_else(|| anyhow!("Cannot split url"))?;
-
-    Ok(segments.find(|s| re.is_match(s)).map(ToString::to_string))
-}
-
 #[cfg(target_os = "macos")]
 #[cfg(test)]
 mod tests {
@@ -247,9 +260,20 @@ mod tests {
         "https://explorer-artifacts.decentraland.zone/dry-run-launcher-rust/pr-196/run-855-19672401394/Decentraland_installer.exe?token=b5876cf1-9b6b-451e-b467-9700f754a8f7",
         "b5876cf1-9b6b-451e-b467-9700f754a8f7"
     )]
-    fn test_token_from_url(#[case] url: &str, #[case] expected_token: &str) -> Result<()> {
-        let token = token_from_url(url)?.ok_or_else(|| anyhow!("Empty url"))?;
+    fn test_token_from_url(#[case] url: &str, #[case] expected_token: &str) -> anyhow::Result<()> {
+        let origin = DownloadOriginData::from_url(url)?;
+        let token = origin.auth_token.ok_or_else(|| anyhow!("No token found"))?;
         assert_eq!(expected_token, token.as_str());
+        Ok(())
+    }
+
+    #[test]
+    fn test_both_token_and_anon_id() -> anyhow::Result<()> {
+        let url = "https://download-gateway.decentraland.zone/391a85da-a3bb-49e2-a45e-96c740c38424/decentraland.dmg?anon_user_id=abc-123";
+        let origin = DownloadOriginData::from_url(url)?;
+        assert_eq!(origin.auth_token.as_deref(), Some("391a85da-a3bb-49e2-a45e-96c740c38424"));
+        assert!(origin.campaign_anon_user_id.is_some());
+        assert_eq!(origin.campaign_anon_user_id.map(|id| id.as_str().to_owned()), Some("abc-123".to_owned()));
         Ok(())
     }
 }

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -19,53 +19,52 @@ pub struct AutoAuth {}
 impl AutoAuth {
     pub fn try_obtain_auth_token() {
         let has_token = AuthTokenStorage::has_token();
-        let has_anon_id = crate::config::campaign_anon_user_id().is_some();
 
         if has_token {
             log::info!("Token already obtained");
         }
 
-        // On macOS, skip extraction only when BOTH are already present
-        #[cfg(target_os = "macos")]
-        if has_token && has_anon_id {
-            return;
-        }
-
-        // On Windows, token extraction is handled by src-auto-auth binary;
-        // only skip if token exists (anon_user_id is also handled there).
+        // On Windows, token + anon_user_id extraction is handled by the
+        // src-auto-auth binary, so we just check the token here.
         #[cfg(not(target_os = "macos"))]
         if has_token {
             return;
         }
 
+        // On macOS, extract from DMG xattr. Skip only when BOTH are present.
         #[cfg(target_os = "macos")]
-        match Self::obtain_token_internal() {
-            Ok(origin) => {
-                // Handle auth token
-                if !has_token {
-                    match origin.auth_token {
-                        Some(token) => {
-                            log::info!("Token obtained");
-                            if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
-                                log::error!("Cannot write token: {e}");
+        {
+            let has_anon_id = crate::config::campaign_anon_user_id().is_some();
+            if has_token && has_anon_id {
+                return;
+            }
+
+            match Self::obtain_token_internal() {
+                Ok(origin) => {
+                    if !has_token {
+                        match origin.auth_token {
+                            Some(token) => {
+                                log::info!("Token obtained");
+                                if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
+                                    log::error!("Cannot write token: {e}");
+                                }
+                            }
+                            None => {
+                                log::warn!("Token value is empty");
                             }
                         }
-                        None => {
-                            log::warn!("Token value is empty");
+                    }
+
+                    if !has_anon_id {
+                        if let Some(ref anon_id) = origin.campaign_anon_user_id {
+                            log::info!("Campaign anon_user_id obtained from DMG origin");
+                            crate::config::write_campaign_anon_user_id(anon_id);
                         }
                     }
                 }
-
-                // Handle anon_user_id independently of token
-                if !has_anon_id {
-                    if let Some(ref anon_id) = origin.campaign_anon_user_id {
-                        log::info!("Campaign anon_user_id obtained from DMG origin");
-                        crate::config::write_campaign_anon_user_id(anon_id);
-                    }
+                Err(e) => {
+                    log::error!("Obtain auth token error: {e}");
                 }
-            }
-            Err(e) => {
-                log::error!("Obtain auth token error: {e}");
             }
         }
     }

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -17,54 +17,53 @@ pub struct DownloadOriginData {
 pub struct AutoAuth {}
 
 impl AutoAuth {
+    /// On Windows, token + `anon_user_id` extraction is handled by the
+    /// `src-auto-auth` binary — this is a no-op.
+    ///
+    /// On macOS, extracts both from the DMG's xattr URLs.
     pub fn try_obtain_auth_token() {
+        #[cfg(target_os = "macos")]
+        Self::try_extract_from_dmg();
+    }
+
+    #[cfg(target_os = "macos")]
+    fn try_extract_from_dmg() {
         let has_token = AuthTokenStorage::has_token();
+        let has_anon_id = crate::config::campaign_anon_user_id().is_some();
 
         if has_token {
             log::info!("Token already obtained");
         }
 
-        // On Windows, token + anon_user_id extraction is handled by the
-        // src-auto-auth binary, so we just check the token here.
-        #[cfg(not(target_os = "macos"))]
-        if has_token {
+        if has_token && has_anon_id {
             return;
         }
 
-        // On macOS, extract from DMG xattr. Skip only when BOTH are present.
-        #[cfg(target_os = "macos")]
-        {
-            let has_anon_id = crate::config::campaign_anon_user_id().is_some();
-            if has_token && has_anon_id {
-                return;
+        match Self::obtain_token_internal() {
+            Ok(origin) => {
+                if !has_token {
+                    match origin.auth_token {
+                        Some(token) => {
+                            log::info!("Token obtained");
+                            if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
+                                log::error!("Cannot write token: {e}");
+                            }
+                        }
+                        None => {
+                            log::warn!("Token value is empty");
+                        }
+                    }
+                }
+
+                if !has_anon_id {
+                    if let Some(ref anon_id) = origin.campaign_anon_user_id {
+                        log::info!("Campaign anon_user_id obtained from DMG origin");
+                        crate::config::write_campaign_anon_user_id(anon_id);
+                    }
+                }
             }
-
-            match Self::obtain_token_internal() {
-                Ok(origin) => {
-                    if !has_token {
-                        match origin.auth_token {
-                            Some(token) => {
-                                log::info!("Token obtained");
-                                if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
-                                    log::error!("Cannot write token: {e}");
-                                }
-                            }
-                            None => {
-                                log::warn!("Token value is empty");
-                            }
-                        }
-                    }
-
-                    if !has_anon_id {
-                        if let Some(ref anon_id) = origin.campaign_anon_user_id {
-                            log::info!("Campaign anon_user_id obtained from DMG origin");
-                            crate::config::write_campaign_anon_user_id(anon_id);
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::error!("Obtain auth token error: {e}");
-                }
+            Err(e) => {
+                log::error!("Obtain auth token error: {e}");
             }
         }
     }

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -5,6 +5,7 @@ use anyhow::{Result, anyhow};
 #[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
 
+#[cfg(target_os = "macos")]
 use auth_token_storage::AuthTokenStorage;
 
 /// Data extracted from the installer's download origin (xattr URLs on macOS,
@@ -21,6 +22,7 @@ impl AutoAuth {
     /// `src-auto-auth` binary — this is a no-op.
     ///
     /// On macOS, extracts both from the DMG's xattr URLs.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn try_obtain_auth_token() {
         #[cfg(target_os = "macos")]
         Self::try_extract_from_dmg();

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -1,7 +1,9 @@
 pub mod anon_user_id;
 pub mod auth_token_storage;
 
-use anyhow::{Result, anyhow};
+#[cfg(target_os = "macos")]
+use anyhow::anyhow;
+use anyhow::Result;
 #[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
 

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -7,38 +7,61 @@ use std::path::{Path, PathBuf};
 
 use auth_token_storage::AuthTokenStorage;
 
+/// Data extracted from the installer's download origin (xattr URLs on macOS,
+/// Zone.Identifier on Windows).
+pub struct DownloadOriginData {
+    pub auth_token: Option<String>,
+    pub campaign_anon_user_id: Option<String>,
+}
+
 pub struct AutoAuth {}
 
 impl AutoAuth {
     pub fn try_obtain_auth_token() {
-        if AuthTokenStorage::has_token() {
-            log::info!("Token already obtained");
+        let has_token = AuthTokenStorage::has_token();
+        let has_anon_id = crate::config::campaign_anon_user_id().is_some();
 
-            // No need to return on windows, just check if token obtained
-            #[cfg(target_os = "macos")]
+        if has_token {
+            log::info!("Token already obtained");
+        }
+
+        // On macOS, skip extraction only when BOTH are already present
+        #[cfg(target_os = "macos")]
+        if has_token && has_anon_id {
+            return;
+        }
+
+        // On Windows, token extraction is handled by src-auto-auth binary;
+        // only skip if token exists (anon_user_id is also handled there).
+        #[cfg(not(target_os = "macos"))]
+        if has_token {
             return;
         }
 
         #[cfg(target_os = "macos")]
         match Self::obtain_token_internal() {
-            Ok((token, campaign_anon_user_id)) => {
+            Ok(origin) => {
                 // Handle auth token
-                match token {
-                    Some(token) => {
-                        log::info!("Token obtained");
-                        if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
-                            log::error!("Cannot write token: {e}");
+                if !has_token {
+                    match origin.auth_token {
+                        Some(token) => {
+                            log::info!("Token obtained");
+                            if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
+                                log::error!("Cannot write token: {e}");
+                            }
                         }
-                    }
-                    None => {
-                        log::warn!("Token value is empty");
+                        None => {
+                            log::warn!("Token value is empty");
+                        }
                     }
                 }
 
                 // Handle anon_user_id independently of token
-                if let Some(anon_id) = campaign_anon_user_id {
-                    log::info!("Campaign anon_user_id obtained: {anon_id}");
-                    crate::config::write_campaign_anon_user_id(&anon_id);
+                if !has_anon_id {
+                    if let Some(ref anon_id) = origin.campaign_anon_user_id {
+                        log::info!("Campaign anon_user_id obtained from DMG origin");
+                        crate::config::write_campaign_anon_user_id(anon_id);
+                    }
                 }
             }
             Err(e) => {
@@ -98,11 +121,11 @@ impl AutoAuth {
         Ok(())
     }
 
-    /// Returns `(auth_token, campaign_anon_user_id)` extracted from the DMG's
-    /// `where-from` xattr URLs.  Both fields are independent — an anon_user_id
+    /// Extracts auth token and campaign `anon_user_id` from the DMG's
+    /// `where-from` xattr URLs.  Both fields are independent — an `anon_user_id`
     /// can be present even when no auth token is found.
     #[cfg(target_os = "macos")]
-    fn obtain_token_internal() -> Result<(Option<String>, Option<String>)> {
+    fn obtain_token_internal() -> Result<DownloadOriginData> {
         use anyhow::Context;
 
         use crate::environment::macos::{dmg_backing_file, dmg_mount_path, where_from_attr};
@@ -113,7 +136,10 @@ impl AutoAuth {
         log::info!("Exe is running from dmg: {dmg_mount_path:?}");
 
         let Some(dmg_mount_path) = dmg_mount_path else {
-            return Ok((None, None));
+            return Ok(DownloadOriginData {
+                auth_token: None,
+                campaign_anon_user_id: None,
+            });
         };
 
         let dmg_file_path = dmg_backing_file(&dmg_mount_path.to_string_lossy())
@@ -158,7 +184,10 @@ impl AutoAuth {
             }
         }
 
-        Ok((found_token, found_anon_user_id))
+        Ok(DownloadOriginData {
+            auth_token: found_token,
+            campaign_anon_user_id: found_anon_user_id,
+        })
     }
 }
 
@@ -185,8 +214,11 @@ pub fn token_from_url(url_str: &str) -> Result<Option<String>> {
         r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
     )?;
 
-    // Search in params
-    for (_, value) in url.query_pairs() {
+    // Search in params — skip anon_user_id to avoid treating it as an auth token
+    for (key, value) in url.query_pairs() {
+        if key == "anon_user_id" {
+            continue;
+        }
         if re.is_match(&value) {
             return Ok(Some(value.to_string()));
         }

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -1,3 +1,4 @@
+pub mod anon_user_id;
 pub mod auth_token_storage;
 
 use anyhow::{Result, anyhow};
@@ -20,15 +21,24 @@ impl AutoAuth {
 
         #[cfg(target_os = "macos")]
         match Self::obtain_token_internal() {
-            Ok(token) => {
-                let Some(token) = token else {
-                    log::warn!("Token value is empty");
-                    return;
-                };
+            Ok((token, campaign_anon_user_id)) => {
+                // Handle auth token
+                match token {
+                    Some(token) => {
+                        log::info!("Token obtained");
+                        if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
+                            log::error!("Cannot write token: {e}");
+                        }
+                    }
+                    None => {
+                        log::warn!("Token value is empty");
+                    }
+                }
 
-                log::info!("Token obtained");
-                if let Err(e) = AuthTokenStorage::write_token(token.as_str()) {
-                    log::error!("Cannot write token: {e}");
+                // Handle anon_user_id independently of token
+                if let Some(anon_id) = campaign_anon_user_id {
+                    log::info!("Campaign anon_user_id obtained: {anon_id}");
+                    crate::config::write_campaign_anon_user_id(&anon_id);
                 }
             }
             Err(e) => {
@@ -88,8 +98,11 @@ impl AutoAuth {
         Ok(())
     }
 
+    /// Returns `(auth_token, campaign_anon_user_id)` extracted from the DMG's
+    /// `where-from` xattr URLs.  Both fields are independent — an anon_user_id
+    /// can be present even when no auth token is found.
     #[cfg(target_os = "macos")]
-    fn obtain_token_internal() -> Result<Option<String>> {
+    fn obtain_token_internal() -> Result<(Option<String>, Option<String>)> {
         use anyhow::Context;
 
         use crate::environment::macos::{dmg_backing_file, dmg_mount_path, where_from_attr};
@@ -100,7 +113,7 @@ impl AutoAuth {
         log::info!("Exe is running from dmg: {dmg_mount_path:?}");
 
         let Some(dmg_mount_path) = dmg_mount_path else {
-            return Ok(None);
+            return Ok((None, None));
         };
 
         let dmg_file_path = dmg_backing_file(&dmg_mount_path.to_string_lossy())
@@ -119,21 +132,33 @@ impl AutoAuth {
             return Err(anyhow!("Dmg does not have where from data"));
         };
 
+        let mut found_token: Option<String> = None;
+        let mut found_anon_user_id: Option<String> = None;
+
         for attr in &where_from {
-            let url = token_from_url(attr);
-            match url {
-                Ok(token) => {
-                    if token.is_some() {
-                        return Ok(token);
+            // Extract auth token
+            if found_token.is_none() {
+                match token_from_url(attr) {
+                    Ok(token) => {
+                        if token.is_some() {
+                            found_token = token;
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Cannot read token from url '{}' due: {}", attr, e);
                     }
                 }
-                Err(e) => {
-                    log::error!("Cannot read url '{}' due: {}", attr, e);
+            }
+
+            // Extract anon_user_id (independently)
+            if found_anon_user_id.is_none() {
+                if let Some(anon_id) = anon_user_id::anon_user_id_from_url(attr) {
+                    found_anon_user_id = Some(anon_id);
                 }
             }
         }
 
-        Ok(None)
+        Ok((found_token, found_anon_user_id))
     }
 }
 

--- a/core/src/auto_auth.rs
+++ b/core/src/auto_auth.rs
@@ -1,5 +1,7 @@
 pub mod anon_user_id;
 pub mod auth_token_storage;
+pub mod campaign_anon_user_id_storage;
+pub mod campaign_attribution_marker;
 
 #[cfg(target_os = "macos")]
 use anyhow::anyhow;
@@ -11,11 +13,14 @@ use std::path::{Path, PathBuf};
 use auth_token_storage::AuthTokenStorage;
 
 use anon_user_id::AnonUserId;
+#[cfg(target_os = "macos")]
+use campaign_anon_user_id_storage::CampaignAnonUserIdStorage;
 
 /// Data extracted from a download URL — auth token and campaign anonymous user ID.
 ///
 /// Both fields are parsed independently from the same URL via `from_url()`,
 /// avoiding ordering or collision issues between the two.
+#[derive(Default)]
 pub struct DownloadOriginData {
     pub auth_token: Option<String>,
     pub campaign_anon_user_id: Option<AnonUserId>,
@@ -33,7 +38,6 @@ impl DownloadOriginData {
             r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
         )?;
 
-        // Extract auth token from query params (skip anon_user_id key) or path segments
         let mut auth_token: Option<String> = None;
 
         for (key, value) in url.query_pairs() {
@@ -55,7 +59,6 @@ impl DownloadOriginData {
             }
         }
 
-        // Extract anon_user_id by key name (validated by AnonUserId::from_url)
         let campaign_anon_user_id = AnonUserId::from_url(url_str);
 
         Ok(Self {
@@ -68,27 +71,21 @@ impl DownloadOriginData {
 pub struct AutoAuth {}
 
 impl AutoAuth {
-    /// On Windows, token + `anon_user_id` extraction is handled by the
-    /// `src-auto-auth` binary — this is a no-op.
+    /// Extracts auth token + campaign `anon_user_id` from the DMG's xattr URLs.
     ///
-    /// On macOS, extracts both from the DMG's xattr URLs.
-    #[allow(clippy::missing_const_for_fn)]
+    /// Windows is handled by the `src-auto-auth` binary, so this is macOS-only.
+    #[cfg(target_os = "macos")]
     pub fn try_obtain_auth_token() {
-        #[cfg(target_os = "macos")]
         Self::try_extract_from_dmg();
     }
 
     #[cfg(target_os = "macos")]
     fn try_extract_from_dmg() {
         let has_token = AuthTokenStorage::has_token();
-        let has_anon_id = crate::config::campaign_anon_user_id().is_some();
+        let has_anon_id = CampaignAnonUserIdStorage::has();
 
         if has_token {
             log::info!("Token already obtained");
-        }
-
-        if has_token && has_anon_id {
-            return;
         }
 
         match Self::obtain_token_internal() {
@@ -110,7 +107,9 @@ impl AutoAuth {
                 if !has_anon_id {
                     if let Some(ref anon_id) = origin.campaign_anon_user_id {
                         log::info!("Campaign anon_user_id obtained from DMG origin");
-                        crate::config::write_campaign_anon_user_id(anon_id.as_str());
+                        if let Err(e) = CampaignAnonUserIdStorage::write(anon_id) {
+                            log::error!("Cannot write campaign anon user id: {e}");
+                        }
                     }
                 }
             }
@@ -157,6 +156,7 @@ impl AutoAuth {
             dest_path.display()
         );
 
+        // Use Apple's ditto, safest and signature-preserving
         let status = std::process::Command::new("ditto")
             .arg(&app_bundle)
             .arg(&dest_path)
@@ -185,10 +185,7 @@ impl AutoAuth {
         log::info!("Exe is running from dmg: {dmg_mount_path:?}");
 
         let Some(dmg_mount_path) = dmg_mount_path else {
-            return Ok(DownloadOriginData {
-                auth_token: None,
-                campaign_anon_user_id: None,
-            });
+            return Ok(DownloadOriginData::default());
         };
 
         let dmg_file_path = dmg_backing_file(&dmg_mount_path.to_string_lossy())
@@ -207,20 +204,14 @@ impl AutoAuth {
             return Err(anyhow!("Dmg does not have where from data"));
         };
 
-        let mut result = DownloadOriginData {
-            auth_token: None,
-            campaign_anon_user_id: None,
-        };
+        let mut result = DownloadOriginData::default();
 
         for attr in &where_from {
             match DownloadOriginData::from_url(attr) {
                 Ok(parsed) => {
-                    if result.auth_token.is_none() {
-                        result.auth_token = parsed.auth_token;
-                    }
-                    if result.campaign_anon_user_id.is_none() {
-                        result.campaign_anon_user_id = parsed.campaign_anon_user_id;
-                    }
+                    result.auth_token = result.auth_token.or(parsed.auth_token);
+                    result.campaign_anon_user_id =
+                        result.campaign_anon_user_id.or(parsed.campaign_anon_user_id);
                 }
                 Err(e) => {
                     log::error!("Cannot parse url '{}': {}", attr, e);
@@ -273,9 +264,15 @@ mod tests {
     fn test_both_token_and_anon_id() -> anyhow::Result<()> {
         let url = "https://download-gateway.decentraland.zone/391a85da-a3bb-49e2-a45e-96c740c38424/decentraland.dmg?anon_user_id=abc-123";
         let origin = DownloadOriginData::from_url(url)?;
-        assert_eq!(origin.auth_token.as_deref(), Some("391a85da-a3bb-49e2-a45e-96c740c38424"));
+        assert_eq!(
+            origin.auth_token.as_deref(),
+            Some("391a85da-a3bb-49e2-a45e-96c740c38424")
+        );
         assert!(origin.campaign_anon_user_id.is_some());
-        assert_eq!(origin.campaign_anon_user_id.map(|id| id.as_str().to_owned()), Some("abc-123".to_owned()));
+        assert_eq!(
+            origin.campaign_anon_user_id.map(|id| id.as_str().to_owned()),
+            Some("abc-123".to_owned())
+        );
         Ok(())
     }
 }

--- a/core/src/auto_auth/anon_user_id.rs
+++ b/core/src/auto_auth/anon_user_id.rs
@@ -1,0 +1,65 @@
+/// Extracts the `anon_user_id` query parameter from a URL.
+///
+/// This deliberately searches by key name (`anon_user_id`) rather than by UUID
+/// regex so it cannot collide with `token_from_url()`, which matches any
+/// UUID-shaped value in query params or path segments.
+pub fn anon_user_id_from_url(url_str: &str) -> Option<String> {
+    let url = url::Url::parse(url_str).ok()?;
+
+    for (key, value) in url.query_pairs() {
+        if key == "anon_user_id" {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_anon_user_id_from_query() {
+        let url = "https://download-gateway.decentraland.zone/391a85da-a3bb-49e2-a45e-96c740c38424/decentraland.dmg?anon_user_id=abc-123-def";
+        assert_eq!(
+            anon_user_id_from_url(url),
+            Some("abc-123-def".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_missing() {
+        let url = "https://download-gateway.decentraland.zone/391a85da-a3bb-49e2-a45e-96c740c38424/decentraland.dmg";
+        assert_eq!(anon_user_id_from_url(url), None);
+    }
+
+    #[test]
+    fn returns_none_for_empty_value() {
+        let url = "https://example.com/file.dmg?anon_user_id=";
+        assert_eq!(anon_user_id_from_url(url), None);
+    }
+
+    #[test]
+    fn ignores_other_uuid_params() {
+        let url = "https://example.com/file.dmg?token=b5876cf1-9b6b-451e-b467-9700f754a8f7&anon_user_id=user-42";
+        assert_eq!(
+            anon_user_id_from_url(url),
+            Some("user-42".to_string())
+        );
+    }
+
+    #[test]
+    fn does_not_match_on_different_key() {
+        let url = "https://example.com/file.dmg?some_other_id=user-42";
+        assert_eq!(anon_user_id_from_url(url), None);
+    }
+
+    #[test]
+    fn handles_invalid_url() {
+        assert_eq!(anon_user_id_from_url("not-a-url"), None);
+    }
+}

--- a/core/src/auto_auth/anon_user_id.rs
+++ b/core/src/auto_auth/anon_user_id.rs
@@ -21,8 +21,9 @@ pub fn anon_user_id_from_url(url_str: &str) -> Option<String> {
     None
 }
 
-/// Only allow alphanumeric chars, hyphens, and underscores, up to 128 chars.
-/// Only allow alphanumeric chars, hyphens, and underscores, up to 128 chars.
+/// Validates an `anon_user_id` value.
+///
+/// Only allows alphanumeric chars, hyphens, and underscores, up to 128 chars.
 /// Must not start with `-` to prevent CLI flag injection.
 pub fn is_valid_anon_user_id(value: &str) -> bool {
     !value.is_empty()

--- a/core/src/auto_auth/anon_user_id.rs
+++ b/core/src/auto_auth/anon_user_id.rs
@@ -22,9 +22,12 @@ pub fn anon_user_id_from_url(url_str: &str) -> Option<String> {
 }
 
 /// Only allow alphanumeric chars, hyphens, and underscores, up to 128 chars.
-fn is_valid_anon_user_id(value: &str) -> bool {
+/// Only allow alphanumeric chars, hyphens, and underscores, up to 128 chars.
+/// Must not start with `-` to prevent CLI flag injection.
+pub fn is_valid_anon_user_id(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 128
+        && !value.starts_with('-')
         && value
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')

--- a/core/src/auto_auth/anon_user_id.rs
+++ b/core/src/auto_auth/anon_user_id.rs
@@ -1,31 +1,53 @@
-/// Extracts the `anon_user_id` query parameter from a URL.
-///
-/// This deliberately searches by key name (`anon_user_id`) rather than by UUID
-/// regex so it cannot collide with `token_from_url()`, which matches any
-/// UUID-shaped value in query params or path segments.
-///
-/// The value is validated against an allowlist pattern to prevent injection of
-/// CLI flags or excessively long strings.
-pub fn anon_user_id_from_url(url_str: &str) -> Option<String> {
-    let url = url::Url::parse(url_str).ok()?;
+use std::fmt;
 
-    for (key, value) in url.query_pairs() {
-        if key == "anon_user_id" {
-            let trimmed = value.trim();
-            if is_valid_anon_user_id(trimmed) {
-                return Some(trimmed.to_string());
-            }
+/// Validated campaign anonymous user ID for attribution tracking.
+///
+/// Guarantees the value is safe to pass as a CLI argument (no flag injection)
+/// and conforms to a reasonable format (alphanumeric + hyphens/underscores, max 128 chars).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnonUserId(String);
+
+impl AnonUserId {
+    /// Parse from a raw string. Returns `None` if invalid.
+    pub fn parse(value: &str) -> Option<Self> {
+        let trimmed = value.trim();
+        if is_valid(trimmed) {
+            Some(Self(trimmed.to_string()))
+        } else {
+            None
         }
     }
 
-    None
+    /// Extract from a URL's `anon_user_id` query parameter.
+    ///
+    /// Searches by key name (`anon_user_id`) rather than by UUID regex
+    /// so it cannot collide with auth token extraction.
+    pub fn from_url(url_str: &str) -> Option<Self> {
+        let url = url::Url::parse(url_str).ok()?;
+
+        for (key, value) in url.query_pairs() {
+            if key == "anon_user_id" {
+                return Self::parse(&value);
+            }
+        }
+
+        None
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-/// Validates an `anon_user_id` value.
-///
-/// Only allows alphanumeric chars, hyphens, and underscores, up to 128 chars.
+impl fmt::Display for AnonUserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Only allow alphanumeric chars, hyphens, and underscores, up to 128 chars.
 /// Must not start with `-` to prevent CLI flag injection.
-pub fn is_valid_anon_user_id(value: &str) -> bool {
+fn is_valid(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 128
         && !value.starts_with('-')
@@ -42,62 +64,77 @@ mod tests {
     fn extracts_anon_user_id_from_query() {
         let url = "https://download-gateway.decentraland.zone/391a85da-a3bb-49e2-a45e-96c740c38424/decentraland.dmg?anon_user_id=abc-123-def";
         assert_eq!(
-            anon_user_id_from_url(url),
-            Some("abc-123-def".to_string())
+            AnonUserId::from_url(url),
+            Some(AnonUserId("abc-123-def".to_string()))
         );
     }
 
     #[test]
     fn returns_none_when_missing() {
         let url = "https://download-gateway.decentraland.zone/391a85da-a3bb-49e2-a45e-96c740c38424/decentraland.dmg";
-        assert_eq!(anon_user_id_from_url(url), None);
+        assert_eq!(AnonUserId::from_url(url), None);
     }
 
     #[test]
     fn returns_none_for_empty_value() {
         let url = "https://example.com/file.dmg?anon_user_id=";
-        assert_eq!(anon_user_id_from_url(url), None);
+        assert_eq!(AnonUserId::from_url(url), None);
     }
 
     #[test]
     fn ignores_other_uuid_params() {
         let url = "https://example.com/file.dmg?token=b5876cf1-9b6b-451e-b467-9700f754a8f7&anon_user_id=user-42";
         assert_eq!(
-            anon_user_id_from_url(url),
-            Some("user-42".to_string())
+            AnonUserId::from_url(url),
+            Some(AnonUserId("user-42".to_string()))
         );
     }
 
     #[test]
     fn does_not_match_on_different_key() {
         let url = "https://example.com/file.dmg?some_other_id=user-42";
-        assert_eq!(anon_user_id_from_url(url), None);
+        assert_eq!(AnonUserId::from_url(url), None);
     }
 
     #[test]
     fn handles_invalid_url() {
-        assert_eq!(anon_user_id_from_url("not-a-url"), None);
+        assert_eq!(AnonUserId::from_url("not-a-url"), None);
     }
 
     #[test]
     fn rejects_value_with_cli_flag_injection() {
         let url = "https://example.com/file.dmg?anon_user_id=--some-explorer-flag";
-        assert_eq!(anon_user_id_from_url(url), None);
+        assert_eq!(AnonUserId::from_url(url), None);
     }
 
     #[test]
     fn rejects_value_too_long() {
         let long_id = "a".repeat(129);
         let url = format!("https://example.com/file.dmg?anon_user_id={long_id}");
-        assert_eq!(anon_user_id_from_url(&url), None);
+        assert_eq!(AnonUserId::from_url(&url), None);
     }
 
     #[test]
     fn accepts_uuid_format() {
         let url = "https://example.com/file.dmg?anon_user_id=62792c33-59e3-4e7f-be42-289c053ecb37";
         assert_eq!(
-            anon_user_id_from_url(url),
-            Some("62792c33-59e3-4e7f-be42-289c053ecb37".to_string())
+            AnonUserId::from_url(url),
+            Some(AnonUserId("62792c33-59e3-4e7f-be42-289c053ecb37".to_string()))
         );
+    }
+
+    #[test]
+    fn parse_valid() {
+        assert_eq!(AnonUserId::parse("abc-123"), Some(AnonUserId("abc-123".to_string())));
+    }
+
+    #[test]
+    fn parse_rejects_empty() {
+        assert_eq!(AnonUserId::parse(""), None);
+    }
+
+    #[test]
+    fn parse_rejects_flag_injection() {
+        assert_eq!(AnonUserId::parse("--flag"), None);
     }
 }

--- a/core/src/auto_auth/anon_user_id.rs
+++ b/core/src/auto_auth/anon_user_id.rs
@@ -3,19 +3,31 @@
 /// This deliberately searches by key name (`anon_user_id`) rather than by UUID
 /// regex so it cannot collide with `token_from_url()`, which matches any
 /// UUID-shaped value in query params or path segments.
+///
+/// The value is validated against an allowlist pattern to prevent injection of
+/// CLI flags or excessively long strings.
 pub fn anon_user_id_from_url(url_str: &str) -> Option<String> {
     let url = url::Url::parse(url_str).ok()?;
 
     for (key, value) in url.query_pairs() {
         if key == "anon_user_id" {
             let trimmed = value.trim();
-            if !trimmed.is_empty() {
+            if is_valid_anon_user_id(trimmed) {
                 return Some(trimmed.to_string());
             }
         }
     }
 
     None
+}
+
+/// Only allow alphanumeric chars, hyphens, and underscores, up to 128 chars.
+fn is_valid_anon_user_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 #[cfg(test)]
@@ -61,5 +73,27 @@ mod tests {
     #[test]
     fn handles_invalid_url() {
         assert_eq!(anon_user_id_from_url("not-a-url"), None);
+    }
+
+    #[test]
+    fn rejects_value_with_cli_flag_injection() {
+        let url = "https://example.com/file.dmg?anon_user_id=--some-explorer-flag";
+        assert_eq!(anon_user_id_from_url(url), None);
+    }
+
+    #[test]
+    fn rejects_value_too_long() {
+        let long_id = "a".repeat(129);
+        let url = format!("https://example.com/file.dmg?anon_user_id={long_id}");
+        assert_eq!(anon_user_id_from_url(&url), None);
+    }
+
+    #[test]
+    fn accepts_uuid_format() {
+        let url = "https://example.com/file.dmg?anon_user_id=62792c33-59e3-4e7f-be42-289c053ecb37";
+        assert_eq!(
+            anon_user_id_from_url(url),
+            Some("62792c33-59e3-4e7f-be42-289c053ecb37".to_string())
+        );
     }
 }

--- a/core/src/auto_auth/anon_user_id.rs
+++ b/core/src/auto_auth/anon_user_id.rs
@@ -2,16 +2,14 @@ use std::fmt;
 
 /// Validated campaign anonymous user ID for attribution tracking.
 ///
-/// Guarantees the value is safe to pass as a CLI argument (no flag injection)
-/// and conforms to a reasonable format (alphanumeric + hyphens/underscores, max 128 chars).
+/// Format constraint: alphanumeric + hyphens/underscores, max 128 chars.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AnonUserId(String);
 
 impl AnonUserId {
-    /// Parse from a raw string. Returns `None` if invalid.
     pub fn parse(value: &str) -> Option<Self> {
         let trimmed = value.trim();
-        if is_valid(trimmed) {
+        if Self::is_valid(trimmed) {
             Some(Self(trimmed.to_string()))
         } else {
             None
@@ -37,23 +35,20 @@ impl AnonUserId {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    fn is_valid(value: &str) -> bool {
+        !value.is_empty()
+            && value.len() <= 128
+            && value
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    }
 }
 
 impl fmt::Display for AnonUserId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
-}
-
-/// Only allow alphanumeric chars, hyphens, and underscores, up to 128 chars.
-/// Must not start with `-` to prevent CLI flag injection.
-fn is_valid(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= 128
-        && !value.starts_with('-')
-        && value
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 #[cfg(test)]
@@ -102,8 +97,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_value_with_cli_flag_injection() {
-        let url = "https://example.com/file.dmg?anon_user_id=--some-explorer-flag";
+    fn rejects_value_with_disallowed_chars() {
+        let url = "https://example.com/file.dmg?anon_user_id=a%20b";
         assert_eq!(AnonUserId::from_url(url), None);
     }
 
@@ -125,16 +120,14 @@ mod tests {
 
     #[test]
     fn parse_valid() {
-        assert_eq!(AnonUserId::parse("abc-123"), Some(AnonUserId("abc-123".to_string())));
+        assert_eq!(
+            AnonUserId::parse("abc-123"),
+            Some(AnonUserId("abc-123".to_string()))
+        );
     }
 
     #[test]
     fn parse_rejects_empty() {
         assert_eq!(AnonUserId::parse(""), None);
-    }
-
-    #[test]
-    fn parse_rejects_flag_injection() {
-        assert_eq!(AnonUserId::parse("--flag"), None);
     }
 }

--- a/core/src/auto_auth/campaign_anon_user_id_storage.rs
+++ b/core/src/auto_auth/campaign_anon_user_id_storage.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+use anyhow::Result;
+
+use crate::installs::campaign_anon_user_id_storage_path;
+
+use super::anon_user_id::AnonUserId;
+
+pub struct CampaignAnonUserIdStorage {}
+
+impl CampaignAnonUserIdStorage {
+    pub fn read() -> Option<AnonUserId> {
+        let path = campaign_anon_user_id_storage_path();
+        let content = fs::read_to_string(&path).ok()?;
+        AnonUserId::parse(content.trim())
+    }
+
+    pub fn has() -> bool {
+        Self::read().is_some()
+    }
+
+    pub fn write(id: &AnonUserId) -> Result<()> {
+        if Self::read().as_ref() == Some(id) {
+            return Ok(());
+        }
+        fs::write(campaign_anon_user_id_storage_path(), id.as_str())?;
+        Ok(())
+    }
+}

--- a/core/src/auto_auth/campaign_attribution_marker.rs
+++ b/core/src/auto_auth/campaign_attribution_marker.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+
+use crate::installs::campaign_attribution_reported_marker_path;
+
+pub struct CampaignAttributionMarker {}
+
+impl CampaignAttributionMarker {
+    pub fn is_reported() -> bool {
+        campaign_attribution_reported_marker_path().exists()
+    }
+
+    pub fn mark_reported() -> Result<()> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        fs::write(
+            campaign_attribution_reported_marker_path(),
+            timestamp.to_string(),
+        )?;
+        Ok(())
+    }
+}

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -82,11 +82,13 @@ pub fn client_additional_arguments() -> Vec<String> {
     arguments_from_key(KEY)
 }
 
+const CAMPAIGN_ANON_USER_ID_KEY: &str = "campaign-anon-user-id";
+const CAMPAIGN_ATTRIBUTION_REPORTED_KEY: &str = "campaign-attribution-reported";
+
 pub fn campaign_anon_user_id() -> Option<String> {
-    const KEY: &str = "campaign-anon-user-id";
     match config_content() {
         Ok(config) => {
-            if let Some(value) = config.get(KEY) {
+            if let Some(value) = config.get(CAMPAIGN_ANON_USER_ID_KEY) {
                 value.as_str().map(ToOwned::to_owned)
             } else {
                 None
@@ -99,17 +101,49 @@ pub fn campaign_anon_user_id() -> Option<String> {
     }
 }
 
+/// Write campaign anon user id to config. Idempotent — skips if already set.
 pub fn write_campaign_anon_user_id(id: &str) {
-    const KEY: &str = "campaign-anon-user-id";
     match config_content() {
         Ok(mut config) => {
-            config.insert(KEY.to_owned(), Value::String(id.to_owned()));
+            if config.get(CAMPAIGN_ANON_USER_ID_KEY).and_then(|v| v.as_str()) == Some(id) {
+                return;
+            }
+            config.insert(CAMPAIGN_ANON_USER_ID_KEY.to_owned(), Value::String(id.to_owned()));
             if let Err(e) = write_config(&config) {
                 log::error!("Cannot write campaign anon user id to config: {e}");
             }
         }
         Err(e) => {
             log::error!("Cannot read config to write campaign anon user id: {e}");
+        }
+    }
+}
+
+/// Returns true if the CAMPAIGN_ATTRIBUTION_DETECTED event has already been reported.
+pub fn campaign_attribution_reported() -> bool {
+    match config_content() {
+        Ok(config) => config
+            .get(CAMPAIGN_ATTRIBUTION_REPORTED_KEY)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
+/// Mark the campaign attribution event as reported so it only fires once.
+pub fn mark_campaign_attribution_reported() {
+    match config_content() {
+        Ok(mut config) => {
+            config.insert(
+                CAMPAIGN_ATTRIBUTION_REPORTED_KEY.to_owned(),
+                Value::Bool(true),
+            );
+            if let Err(e) = write_config(&config) {
+                log::error!("Cannot mark campaign attribution as reported: {e}");
+            }
+        }
+        Err(e) => {
+            log::error!("Cannot read config to mark campaign attribution: {e}");
         }
     }
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -81,3 +81,35 @@ pub fn client_additional_arguments() -> Vec<String> {
     const KEY: &str = "client-additional-arguments";
     arguments_from_key(KEY)
 }
+
+pub fn campaign_anon_user_id() -> Option<String> {
+    const KEY: &str = "campaign-anon-user-id";
+    match config_content() {
+        Ok(config) => {
+            if let Some(value) = config.get(KEY) {
+                value.as_str().map(ToOwned::to_owned)
+            } else {
+                None
+            }
+        }
+        Err(e) => {
+            log::error!("Cannot read config for campaign anon user id: {e}");
+            None
+        }
+    }
+}
+
+pub fn write_campaign_anon_user_id(id: &str) {
+    const KEY: &str = "campaign-anon-user-id";
+    match config_content() {
+        Ok(mut config) => {
+            config.insert(KEY.to_owned(), Value::String(id.to_owned()));
+            if let Err(e) = write_config(&config) {
+                log::error!("Cannot write campaign anon user id to config: {e}");
+            }
+        }
+        Err(e) => {
+            log::error!("Cannot read config to write campaign anon user id: {e}");
+        }
+    }
+}

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -83,7 +83,6 @@ pub fn client_additional_arguments() -> Vec<String> {
 }
 
 const CAMPAIGN_ANON_USER_ID_KEY: &str = "campaign-anon-user-id";
-const CAMPAIGN_ATTRIBUTION_REPORTED_KEY: &str = "campaign-attribution-reported";
 
 pub fn campaign_anon_user_id() -> Option<String> {
     match config_content() {
@@ -115,35 +114,6 @@ pub fn write_campaign_anon_user_id(id: &str) {
         }
         Err(e) => {
             log::error!("Cannot read config to write campaign anon user id: {e}");
-        }
-    }
-}
-
-/// Returns true if the `CAMPAIGN_ATTRIBUTION_DETECTED` event has already been reported.
-pub fn campaign_attribution_reported() -> bool {
-    match config_content() {
-        Ok(config) => config
-            .get(CAMPAIGN_ATTRIBUTION_REPORTED_KEY)
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false),
-        Err(_) => false,
-    }
-}
-
-/// Mark the campaign attribution event as reported so it only fires once.
-pub fn mark_campaign_attribution_reported() {
-    match config_content() {
-        Ok(mut config) => {
-            config.insert(
-                CAMPAIGN_ATTRIBUTION_REPORTED_KEY.to_owned(),
-                Value::Bool(true),
-            );
-            if let Err(e) = write_config(&config) {
-                log::error!("Cannot mark campaign attribution as reported: {e}");
-            }
-        }
-        Err(e) => {
-            log::error!("Cannot read config to mark campaign attribution: {e}");
         }
     }
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -119,12 +119,12 @@ pub fn write_campaign_anon_user_id(id: &str) {
     }
 }
 
-/// Returns true if the CAMPAIGN_ATTRIBUTION_DETECTED event has already been reported.
+/// Returns true if the `CAMPAIGN_ATTRIBUTION_DETECTED` event has already been reported.
 pub fn campaign_attribution_reported() -> bool {
     match config_content() {
         Ok(config) => config
             .get(CAMPAIGN_ATTRIBUTION_REPORTED_KEY)
-            .and_then(|v| v.as_bool())
+            .and_then(serde_json::Value::as_bool)
             .unwrap_or(false),
         Err(_) => false,
     }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -81,39 +81,3 @@ pub fn client_additional_arguments() -> Vec<String> {
     const KEY: &str = "client-additional-arguments";
     arguments_from_key(KEY)
 }
-
-const CAMPAIGN_ANON_USER_ID_KEY: &str = "campaign-anon-user-id";
-
-pub fn campaign_anon_user_id() -> Option<String> {
-    match config_content() {
-        Ok(config) => {
-            if let Some(value) = config.get(CAMPAIGN_ANON_USER_ID_KEY) {
-                value.as_str().map(ToOwned::to_owned)
-            } else {
-                None
-            }
-        }
-        Err(e) => {
-            log::error!("Cannot read config for campaign anon user id: {e}");
-            None
-        }
-    }
-}
-
-/// Write campaign anon user id to config. Idempotent — skips if already set.
-pub fn write_campaign_anon_user_id(id: &str) {
-    match config_content() {
-        Ok(mut config) => {
-            if config.get(CAMPAIGN_ANON_USER_ID_KEY).and_then(|v| v.as_str()) == Some(id) {
-                return;
-            }
-            config.insert(CAMPAIGN_ANON_USER_ID_KEY.to_owned(), Value::String(id.to_owned()));
-            if let Err(e) = write_config(&config) {
-                log::error!("Cannot write campaign anon user id to config: {e}");
-            }
-        }
-        Err(e) => {
-            log::error!("Cannot read config to write campaign anon user id: {e}");
-        }
-    }
-}

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -94,6 +94,10 @@ pub fn campaign_anon_user_id_file_path() -> PathBuf {
     explorer_path().join("campaign-anon-user-id.txt")
 }
 
+pub fn campaign_attribution_reported_path() -> PathBuf {
+    explorer_path().join("campaign-attribution-reported")
+}
+
 // There is no point to recovery if the app failed to create working directory
 #[allow(clippy::expect_used)]
 fn get_app_base_path() -> PathBuf {

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -91,12 +91,12 @@ pub fn deeplink_bridge_path() -> PathBuf {
     explorer_path().join("deeplink-bridge.json")
 }
 
-pub fn campaign_anon_user_id_file_path() -> PathBuf {
+pub fn campaign_anon_user_id_storage_path() -> PathBuf {
     explorer_path().join("campaign-anon-user-id.txt")
 }
 
-pub fn campaign_attribution_reported_path() -> PathBuf {
-    explorer_path().join("campaign-attribution-reported")
+pub fn campaign_attribution_reported_marker_path() -> PathBuf {
+    explorer_path().join("campaign-attribution-reported-marker.txt")
 }
 
 // There is no point to recovery if the app failed to create working directory
@@ -502,9 +502,11 @@ impl InstallsHub {
             output.insert(0, value.into());
         }
 
-        if let Some(anon_id) = config::campaign_anon_user_id() {
+        if let Some(anon_id) =
+            crate::auto_auth::campaign_anon_user_id_storage::CampaignAnonUserIdStorage::read()
+        {
             output.push("--campaign_anon_user_id".to_string());
-            output.push(anon_id);
+            output.push(anon_id.as_str().to_owned());
         }
 
         let mut additionals = config::client_additional_arguments();

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -90,6 +90,10 @@ pub fn deeplink_bridge_path() -> PathBuf {
     explorer_path().join("deeplink-bridge.json")
 }
 
+pub fn campaign_anon_user_id_file_path() -> PathBuf {
+    explorer_path().join("campaign-anon-user-id.txt")
+}
+
 // There is no point to recovery if the app failed to create working directory
 #[allow(clippy::expect_used)]
 fn get_app_base_path() -> PathBuf {
@@ -491,6 +495,11 @@ impl InstallsHub {
 
         if let Some(value) = deeplink {
             output.insert(0, value.into());
+        }
+
+        if let Some(anon_id) = config::campaign_anon_user_id() {
+            output.push("--campaign_anon_user_id".to_string());
+            output.push(anon_id);
         }
 
         let mut additionals = config::client_additional_arguments();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,7 +24,7 @@ pub mod analytics;
 pub mod app;
 pub mod auto_auth;
 pub mod channel;
-mod config;
+pub mod config;
 mod deeplink_bridge;
 pub mod environment;
 pub mod errors;

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -3,7 +3,9 @@
 
 use dcl_launcher_core::{
     anyhow::{Context, Result, anyhow},
+    auto_auth::anon_user_id::anon_user_id_from_url,
     auto_auth::auth_token_storage::AuthTokenStorage,
+    config,
     log, logs,
 };
 
@@ -26,10 +28,6 @@ fn main() {
 
 fn main_internal() -> Result<()> {
     log::info!("Start auto auth script v{}", std::env!("CARGO_PKG_VERSION"));
-    if AuthTokenStorage::has_token() {
-        log::info!("Token already installed");
-        return Ok(());
-    }
 
     let args: Vec<String> = std::env::args().collect();
     log::info!("Args: {args:?}");
@@ -39,10 +37,83 @@ fn main_internal() -> Result<()> {
         .ok_or_else(|| anyhow!("Installer path is not provided"))?;
     log::info!("Installer path: {installer_path}");
 
+    // Extract anon_user_id from Zone.Identifier URLs (independent of auth token)
+    extract_anon_user_id_from_zone(installer_path);
+
+    // Also check for a file-based campaign anon user id (future mechanism)
+    extract_anon_user_id_from_file();
+
+    if AuthTokenStorage::has_token() {
+        log::info!("Token already installed");
+        return Ok(());
+    }
+
     let token = token_from_file_by_zone_attr(installer_path)?;
     AuthTokenStorage::write_token(token.as_str())?;
     log::info!("Token write complete");
     Ok(())
+}
+
+/// Try to extract `anon_user_id` from Zone.Identifier URLs and persist it to config.
+fn extract_anon_user_id_from_zone(installer_path: &str) {
+    // Already have a campaign anon user id — skip
+    if config::campaign_anon_user_id().is_some() {
+        log::info!("Campaign anon_user_id already present in config");
+        return;
+    }
+
+    let content = match zone_identifier_content(installer_path)
+        .or_else(|e| {
+            log::error!("ADS read for anon_user_id failed via CAPI, fallback to PowerShell: {e:?}");
+            zone_identifier_content_powershell(installer_path)
+        }) {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("Cannot read Zone.Identifier for anon_user_id: {e:?}");
+            return;
+        }
+    };
+
+    let zone_info = parsed_zone_identifier(&content);
+
+    // Check both host_url and referrer_url for anon_user_id
+    let urls: Vec<&str> = [zone_info.host_url.as_deref(), zone_info.referrer_url.as_deref()]
+        .into_iter()
+        .flatten()
+        .collect();
+
+    for url in urls {
+        if let Some(anon_id) = anon_user_id_from_url(url) {
+            log::info!("Campaign anon_user_id extracted from Zone.Identifier: {anon_id}");
+            config::write_campaign_anon_user_id(&anon_id);
+            return;
+        }
+    }
+
+    log::info!("No campaign anon_user_id found in Zone.Identifier URLs");
+}
+
+/// Check for a file-based campaign anon user id (`campaign-anon-user-id.txt`).
+/// This supports a future mechanism where the installer can drop the id into a
+/// well-known file location.
+fn extract_anon_user_id_from_file() {
+    if config::campaign_anon_user_id().is_some() {
+        return;
+    }
+
+    let path = dcl_launcher_core::installs::campaign_anon_user_id_file_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => {
+            let trimmed = content.trim();
+            if !trimmed.is_empty() {
+                log::info!("Campaign anon_user_id extracted from file: {trimmed}");
+                config::write_campaign_anon_user_id(trimmed);
+            }
+        }
+        Err(_) => {
+            // File doesn't exist — expected, silently skip
+        }
+    }
 }
 
 // Zone.Identifier

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -84,7 +84,7 @@ fn extract_anon_user_id_from_zone(installer_path: &str) {
 
     for url in urls {
         if let Some(anon_id) = anon_user_id_from_url(url) {
-            log::info!("Campaign anon_user_id extracted from Zone.Identifier: {anon_id}");
+            log::info!("Campaign anon_user_id extracted from Zone.Identifier");
             config::write_campaign_anon_user_id(&anon_id);
             return;
         }
@@ -106,8 +106,12 @@ fn extract_anon_user_id_from_file() {
         Ok(content) => {
             let trimmed = content.trim();
             if !trimmed.is_empty() {
-                log::info!("Campaign anon_user_id extracted from file: {trimmed}");
+                log::info!("Campaign anon_user_id extracted from file");
                 config::write_campaign_anon_user_id(trimmed);
+            }
+            // Delete after reading to prevent stale attribution on reinstalls
+            if let Err(e) = std::fs::remove_file(&path) {
+                log::warn!("Cannot delete campaign anon user id file: {e}");
             }
         }
         Err(_) => {

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -5,7 +5,7 @@ use dcl_launcher_core::{
     anyhow::{Context, Result, anyhow},
     auto_auth::anon_user_id::AnonUserId,
     auto_auth::auth_token_storage::AuthTokenStorage,
-    config,
+    auto_auth::campaign_anon_user_id_storage::CampaignAnonUserIdStorage,
     log, logs,
 };
 
@@ -37,11 +37,16 @@ fn main_internal() -> Result<()> {
         .ok_or_else(|| anyhow!("Installer path is not provided"))?;
     log::info!("Installer path: {installer_path}");
 
-    // Extract anon_user_id from Zone.Identifier URLs (independent of auth token)
-    extract_anon_user_id_from_zone(installer_path);
-
-    // Also check for a file-based campaign anon user id (future mechanism)
-    extract_anon_user_id_from_file();
+    if CampaignAnonUserIdStorage::has() {
+        log::info!("Campaign anon_user_id already present in storage");
+    } else if let Some(anon_id) = extract_anon_user_id_from_zone(installer_path) {
+        log::info!("Campaign anon_user_id extracted from Zone.Identifier");
+        if let Err(e) = CampaignAnonUserIdStorage::write(&anon_id) {
+            log::error!("Cannot write campaign anon user id: {e}");
+        }
+    } else {
+        log::info!("No campaign anon_user_id found in Zone.Identifier URLs");
+    }
 
     if AuthTokenStorage::has_token() {
         log::info!("Token already installed");
@@ -54,70 +59,25 @@ fn main_internal() -> Result<()> {
     Ok(())
 }
 
-/// Try to extract `anon_user_id` from Zone.Identifier URLs and persist it to config.
-fn extract_anon_user_id_from_zone(installer_path: &str) {
-    // Already have a campaign anon user id — skip
-    if config::campaign_anon_user_id().is_some() {
-        log::info!("Campaign anon_user_id already present in config");
-        return;
-    }
-
-    let content = match zone_identifier_content(installer_path)
-        .or_else(|e| {
-            log::error!("ADS read for anon_user_id failed via CAPI, fallback to PowerShell: {e:?}");
-            zone_identifier_content_powershell(installer_path)
-        }) {
+/// Try to extract `anon_user_id` from Zone.Identifier URLs.
+fn extract_anon_user_id_from_zone(installer_path: &str) -> Option<AnonUserId> {
+    let content = match zone_identifier_content(installer_path).or_else(|e| {
+        log::error!("ADS read for anon_user_id failed via CAPI, fallback to PowerShell: {e:?}");
+        zone_identifier_content_powershell(installer_path)
+    }) {
         Ok(c) => c,
         Err(e) => {
             log::error!("Cannot read Zone.Identifier for anon_user_id: {e:?}");
-            return;
+            return None;
         }
     };
 
     let zone_info = parsed_zone_identifier(&content);
 
-    // Check both host_url and referrer_url for anon_user_id
-    let urls: Vec<&str> = [zone_info.host_url.as_deref(), zone_info.referrer_url.as_deref()]
+    [zone_info.host_url.as_deref(), zone_info.referrer_url.as_deref()]
         .into_iter()
         .flatten()
-        .collect();
-
-    for url in urls {
-        if let Some(anon_id) = AnonUserId::from_url(url) {
-            log::info!("Campaign anon_user_id extracted from Zone.Identifier");
-            config::write_campaign_anon_user_id(anon_id.as_str());
-            return;
-        }
-    }
-
-    log::info!("No campaign anon_user_id found in Zone.Identifier URLs");
-}
-
-/// Check for a file-based campaign anon user id (`campaign-anon-user-id.txt`).
-/// This supports a future mechanism where the installer can drop the id into a
-/// well-known file location.
-fn extract_anon_user_id_from_file() {
-    if config::campaign_anon_user_id().is_some() {
-        return;
-    }
-
-    let path = dcl_launcher_core::installs::campaign_anon_user_id_file_path();
-    match std::fs::read_to_string(&path) {
-        Ok(content) => {
-            let trimmed = content.trim();
-            if let Some(anon_id) = AnonUserId::parse(trimmed) {
-                log::info!("Campaign anon_user_id extracted from file");
-                config::write_campaign_anon_user_id(anon_id.as_str());
-            }
-            // Delete after reading to prevent stale attribution on reinstalls
-            if let Err(e) = std::fs::remove_file(&path) {
-                log::warn!("Cannot delete campaign anon user id file: {e}");
-            }
-        }
-        Err(_) => {
-            // File doesn't exist — expected, silently skip
-        }
-    }
+        .find_map(AnonUserId::from_url)
 }
 
 // Zone.Identifier

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -3,7 +3,7 @@
 
 use dcl_launcher_core::{
     anyhow::{Context, Result, anyhow},
-    auto_auth::anon_user_id::{anon_user_id_from_url, is_valid_anon_user_id},
+    auto_auth::anon_user_id::AnonUserId,
     auto_auth::auth_token_storage::AuthTokenStorage,
     config,
     log, logs,
@@ -83,9 +83,9 @@ fn extract_anon_user_id_from_zone(installer_path: &str) {
         .collect();
 
     for url in urls {
-        if let Some(anon_id) = anon_user_id_from_url(url) {
+        if let Some(anon_id) = AnonUserId::from_url(url) {
             log::info!("Campaign anon_user_id extracted from Zone.Identifier");
-            config::write_campaign_anon_user_id(&anon_id);
+            config::write_campaign_anon_user_id(anon_id.as_str());
             return;
         }
     }
@@ -105,9 +105,9 @@ fn extract_anon_user_id_from_file() {
     match std::fs::read_to_string(&path) {
         Ok(content) => {
             let trimmed = content.trim();
-            if is_valid_anon_user_id(trimmed) {
+            if let Some(anon_id) = AnonUserId::parse(trimmed) {
                 log::info!("Campaign anon_user_id extracted from file");
-                config::write_campaign_anon_user_id(trimmed);
+                config::write_campaign_anon_user_id(anon_id.as_str());
             }
             // Delete after reading to prevent stale attribution on reinstalls
             if let Err(e) = std::fs::remove_file(&path) {
@@ -135,17 +135,16 @@ fn token_from_file_by_zone_attr(path: &str) -> Result<String> {
 }
 
 fn token_from_zone_info(zone_info: ZoneInfo) -> Result<String> {
-    if let Some(url) = &zone_info.host_url {
-        let token = dcl_launcher_core::auto_auth::token_from_url(url)?;
-        if let Some(token) = token {
-            return Ok(token);
-        }
-    }
+    use dcl_launcher_core::auto_auth::DownloadOriginData;
 
-    if let Some(url) = &zone_info.referrer_url {
-        let token = dcl_launcher_core::auto_auth::token_from_url(url)?;
-        if let Some(token) = token {
-            return Ok(token);
+    for url in [zone_info.host_url.as_deref(), zone_info.referrer_url.as_deref()]
+        .into_iter()
+        .flatten()
+    {
+        if let Ok(origin) = DownloadOriginData::from_url(url) {
+            if let Some(token) = origin.auth_token {
+                return Ok(token);
+            }
         }
     }
 

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -3,7 +3,7 @@
 
 use dcl_launcher_core::{
     anyhow::{Context, Result, anyhow},
-    auto_auth::anon_user_id::anon_user_id_from_url,
+    auto_auth::anon_user_id::{anon_user_id_from_url, is_valid_anon_user_id},
     auto_auth::auth_token_storage::AuthTokenStorage,
     config,
     log, logs,
@@ -105,7 +105,7 @@ fn extract_anon_user_id_from_file() {
     match std::fs::read_to_string(&path) {
         Ok(content) => {
             let trimmed = content.trim();
-            if !trimmed.is_empty() {
+            if is_valid_anon_user_id(trimmed) {
                 log::info!("Campaign anon_user_id extracted from file");
                 config::write_campaign_anon_user_id(trimmed);
             }


### PR DESCRIPTION
# feat: extract and forward campaign anon_user_id for attribution

## Summary
Extracts `anon_user_id` from the download URL metadata, stores it in config, fires a campaign attribution event, injects it on all analytics events, and forwards it to the Explorer as a CLI argument.

## Changes

**New: `core/src/auto_auth/anon_user_id.rs`**
- `anon_user_id_from_url(url) -> Option<String>` — extracts `anon_user_id` query param by key name
- Unit tests covering: URL with both token and anon_user_id, URL with only anon_user_id, URL with neither, encoded values

**Modified: `core/src/auto_auth.rs`**
- `obtain_token_internal()` now returns `(Option<String>, Option<String>)` — auth token AND anon_user_id
- `try_obtain_auth_token()` handles both independently: writes anon_user_id to config even if no auth token found

**Modified: `core/src/config.rs`**
- `campaign_anon_user_id() -> Option<String>` — reads "campaign-anon-user-id" from config.json
- `write_campaign_anon_user_id(id)` — writes "campaign-anon-user-id" to config.json

**Modified: `core/src/analytics/event.rs`**
- New `CampaignAttributionDetected { anon_user_id }` event variant

**Modified: `core/src/analytics/client.rs`**
- Added `campaign_anon_user_id: Option<String>` field
- `track()` injects `campaignAnonUserId` property on every event when present

**Modified: `core/src/analytics.rs`**
- `CreateArgs` accepts `campaign_anon_user_id`
- Threads it through to `AnalyticsClient`

**Modified: `core/src/app.rs`**
- Moved `AutoAuth::try_obtain_auth_token()` BEFORE `Analytics::new_from_env()` — attribution available on first launch
- Reads `campaign_anon_user_id` from config and passes to analytics init
- Fires `CAMPAIGN_ATTRIBUTION_DETECTED` event if present

**Modified: `core/src/installs.rs`**
- `explorer_params()` appends `--campaign_anon_user_id {id}` when present

**Modified: `src-auto-auth/src/main.rs` (Windows)**
- Extracts `anon_user_id` from Zone.Identifier URLs independently of auth token
- Also reads from `campaign-anon-user-id.txt` (written by NSIS installer)
- Writes to config via `config::write_campaign_anon_user_id()`

## Data flow
```
macOS:
  DMG xattr contains download URL with ?anon_user_id=abc-123
  → auto_auth extracts by key name (not UUID regex)
  → writes to config.json: "campaign-anon-user-id": "abc-123"
  → analytics injects campaignAnonUserId on all events
  → explorer launched with --campaign_anon_user_id abc-123

Windows:
  Zone.Identifier ADS contains download URL with ?anon_user_id=abc-123
  + NSIS writes campaign-anon-user-id.txt during install
  → src-auto-auth reads from both sources
  → writes to config.json
  → same analytics + explorer flow as macOS
```

## Test plan
- [ ] `anon_user_id_from_url()` unit tests pass
- [ ] macOS: download DMG with `?anon_user_id=test` → install → verify config.json has "campaign-anon-user-id"
- [ ] Windows: download EXE with `?anon_user_id=test` → install → verify config.json
- [ ] Segment events contain `campaignAnonUserId` property
- [ ] Explorer receives `--campaign_anon_user_id` argument
- [ ] Download without `anon_user_id` → no errors, no campaign attribution