### PR TITLE
feat: focus opened explorer

### DIFF
--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -52,8 +52,11 @@ pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 fn bring_explorer_to_front() {
     #[cfg(target_os = "macos")]
     {
+        // Derive the app name from the .app bundle constant (e.g. "Decentraland.app" → "Decentraland")
+        let app_name = crate::installs::explorer_app_name();
+        let script = format!("tell application \"{app_name}\" to activate");
         let result = std::process::Command::new("osascript")
-            .args(["-e", "tell application \"Explorer\" to activate"])
+            .args(["-e", &script])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn();

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -50,7 +50,7 @@ pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 /// Best-effort attempt to bring the Explorer window to the front.
 #[cfg(target_os = "macos")]
 fn try_bring_explorer_to_front() {
-    let app_name = crate::installs::explorer_app_name();
+    let app_name = crate::installs::EXPLORER_MAC_APP_NAME;
     let script = format!("tell application \"{app_name}\" to activate");
     let result = std::process::Command::new("osascript")
         .args(["-e", &script])

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -48,21 +48,17 @@ impl From<std::io::Error> for PlaceDeeplinkError {
 pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 
 /// Best-effort attempt to bring the Explorer window to the front.
-#[allow(clippy::missing_const_for_fn)]
-fn bring_explorer_to_front() {
-    #[cfg(target_os = "macos")]
-    {
-        // Derive the app name from the .app bundle constant (e.g. "Decentraland.app" → "Decentraland")
-        let app_name = crate::installs::explorer_app_name();
-        let script = format!("tell application \"{app_name}\" to activate");
-        let result = std::process::Command::new("osascript")
-            .args(["-e", &script])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
-        if let Err(e) = result {
-            log::warn!("Failed to bring Explorer to front: {e}");
-        }
+#[cfg(target_os = "macos")]
+fn try_bring_explorer_to_front() {
+    let app_name = crate::installs::explorer_app_name();
+    let script = format!("tell application \"{app_name}\" to activate");
+    let result = std::process::Command::new("osascript")
+        .args(["-e", &script])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+    if let Err(e) = result {
+        log::warn!("Failed to bring Explorer to front: {e}");
     }
 }
 
@@ -82,7 +78,8 @@ pub async fn place_deeplink_and_wait_until_consumed(
     }
 
     // Bring the Explorer window to the front
-    bring_explorer_to_front();
+    #[cfg(target_os = "macos")]
+    try_bring_explorer_to_front();
 
     // Wait until file is deleted or operation is cancelled
     loop {

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -47,6 +47,21 @@ impl From<std::io::Error> for PlaceDeeplinkError {
 
 pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 
+/// Best-effort attempt to bring the Explorer window to the front.
+fn bring_explorer_to_front() {
+    #[cfg(target_os = "macos")]
+    {
+        let result = std::process::Command::new("osascript")
+            .args(["-e", "tell application \"Decentraland\" to activate"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        if let Err(e) = result {
+            log::warn!("Failed to bring Explorer to front: {e}");
+        }
+    }
+}
+
 pub async fn place_deeplink_and_wait_until_consumed(
     deeplink: DeepLink,
     token: CancellationToken,
@@ -61,6 +76,9 @@ pub async fn place_deeplink_and_wait_until_consumed(
         let json = serde_json::to_string(&dto)?;
         File::create(&path)?.write_all(json.as_bytes())?;
     }
+
+    // Bring the Explorer window to the front
+    bring_explorer_to_front();
 
     // Wait until file is deleted or operation is cancelled
     loop {

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -48,6 +48,7 @@ impl From<std::io::Error> for PlaceDeeplinkError {
 pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 
 /// Best-effort attempt to bring the Explorer window to the front.
+#[allow(clippy::missing_const_for_fn)]
 fn bring_explorer_to_front() {
     #[cfg(target_os = "macos")]
     {

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -52,7 +52,7 @@ fn bring_explorer_to_front() {
     #[cfg(target_os = "macos")]
     {
         let result = std::process::Command::new("osascript")
-            .args(["-e", "tell application \"Decentraland\" to activate"])
+            .args(["-e", "tell application \"Explorer\" to activate"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn();

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -39,15 +39,9 @@ const APP_NAME: &str = "DecentralandLauncherLight";
 const EXPLORER_DOWNLOADED_FILENAME: &str = "decentraland.zip";
 
 #[cfg(target_os = "macos")]
-const EXPLORER_MAC_APP_PATH: &str = "Decentraland.app";
-
-/// Returns the macOS app name without the `.app` extension (e.g. "Decentraland").
+pub const EXPLORER_MAC_APP_NAME: &str = "Decentraland";
 #[cfg(target_os = "macos")]
-pub fn explorer_app_name() -> &'static str {
-    EXPLORER_MAC_APP_PATH
-        .strip_suffix(".app")
-        .unwrap_or(EXPLORER_MAC_APP_PATH)
-}
+const EXPLORER_MAC_APP_PATH: &str = concat!("Decentraland", ".app");
 
 #[cfg(target_os = "windows")]
 const EXPLORER_WIN_BIN_PATH: &str = "Decentraland.exe";

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -40,6 +40,14 @@ const EXPLORER_DOWNLOADED_FILENAME: &str = "decentraland.zip";
 #[cfg(target_os = "macos")]
 const EXPLORER_MAC_APP_PATH: &str = "Decentraland.app";
 
+/// Returns the macOS app name without the `.app` extension (e.g. "Decentraland").
+#[cfg(target_os = "macos")]
+pub fn explorer_app_name() -> &'static str {
+    EXPLORER_MAC_APP_PATH
+        .strip_suffix(".app")
+        .unwrap_or(EXPLORER_MAC_APP_PATH)
+}
+
 #[cfg(target_os = "windows")]
 const EXPLORER_WIN_BIN_PATH: &str = "Decentraland.exe";
 


### PR DESCRIPTION
# feat: bring Explorer to front on deeplink reuse (macOS)

## Summary

When the launcher receives a `decentraland://` deeplink while an Explorer instance is already running, it now brings the Explorer window to the foreground automatically on macOS.

## Why

After completing authentication in the browser, auth triggers a `decentraland://` deeplink to return the user to the Explorer. Previously, the deeplink was processed correctly (written to the bridge file for the running instance) but the Explorer window stayed behind the browser — the user had to manually Alt-Tab back. Now the Explorer activates automatically.

## Changes

**`core/src/deeplink_bridge.rs`**
- Added `bring_explorer_to_front()` — uses `osascript -e 'tell application "Explorer" to activate'` on macOS
- Called after writing the bridge file in `place_deeplink_and_wait_until_consumed()`
- Best-effort: logs a warning if it fails, does not block the deeplink flow
- macOS only via `#[cfg(target_os = "macos")]`, no-op on other platforms

## Testing

1. Open Explorer (zone or prod)
2. Click Login → browser opens auth page
3. Complete login (MetaMask or social)
4. Auth triggers `decentraland://` deeplink
5. **Expected**: Explorer window comes to the front automatically instead of staying behind the browser
