### PR TITLE
fix: propagate install errors and handle rename collisions

### DIFF
--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -211,13 +211,13 @@ impl StepError {
                 "Could not rename \"latest\" folder. Delete everything and start over."
             }
             Self::E3005_STALE_BUILD_CLEANUP_FAILED { .. } => {
-                "We couldn't clean up a previous build folder before installing. Please check folder permissions or close any programs that might be using Decentraland files."
+                "We couldn't clean up a previous build folder. Please close the Decentraland client if it's running and try again."
             }
             Self::E3006_RENAME_BACK_FAILED { .. } => {
-                "We couldn't move the current build aside before installing the update. Please check folder permissions or close any programs that might be using Decentraland files."
+                "We couldn't move the current build aside before installing the update. Please close the Decentraland client if it's running and try again."
             }
             Self::E3007_VERSION_DATA_WRITE_FAILED { .. } => {
-                "We couldn't save the updated version information. Please check folder permissions and try again."
+                "We couldn't save the updated version information. Please close the Decentraland client if it's running and try again."
             }
         }
     }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -109,6 +109,20 @@ pub enum StepError {
     E3002_PLACE_DEEPLINK_ERROR(#[from] PlaceDeeplinkError),
     E3003_CANT_GET_VERSION,
     E3004_CANT_RENAME_LATEST,
+    E3005_STALE_BUILD_CLEANUP_FAILED {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    E3006_RENAME_BACK_FAILED {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    E3007_VERSION_DATA_WRITE_FAILED {
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 impl StepError {
@@ -195,6 +209,15 @@ impl StepError {
             }
             Self::E3004_CANT_RENAME_LATEST => {
                 "Could not rename \"latest\" folder. Delete everything and start over."
+            }
+            Self::E3005_STALE_BUILD_CLEANUP_FAILED { .. } => {
+                "We couldn't clean up a previous build folder before installing. Please check folder permissions or close any programs that might be using Decentraland files."
+            }
+            Self::E3006_RENAME_BACK_FAILED { .. } => {
+                "We couldn't move the current build aside before installing the update. Please check folder permissions or close any programs that might be using Decentraland files."
+            }
+            Self::E3007_VERSION_DATA_WRITE_FAILED { .. } => {
+                "We couldn't save the updated version information. Please check folder permissions and try again."
             }
         }
     }

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -342,6 +342,7 @@ impl InstallStep {
             &recent_download.version,
             Some(recent_download.downloaded_path),
         )
+        .and_then(|()| installs::rename_explorer_to_latest())
     }
 
     async fn recent_download_and_update_state(
@@ -387,8 +388,7 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
                     version: version.clone(),
                 })
                 .await;
-            let result = Self::execute_internal(download)
-                .and_then(|()| installs::rename_explorer_to_latest());
+            let result = Self::execute_internal(download);
             if let Err(e) = &result {
                 self.analytics
                     .lock()

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -377,7 +377,7 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
         state: Arc<Mutex<LaunchFlowState>>,
     ) -> StepResult {
         let recent_download = Self::recent_download_and_update_state(state).await;
-        
+
         if let Some(download) = recent_download {
             let version = download.version.clone();
             self.analytics
@@ -397,16 +397,17 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
                         error: e.to_string(),
                     })
                     .await;
-            } else {
-                self.analytics
-                    .lock()
-                    .await
-                    .track_and_flush_silent(Event::INSTALL_VERSION_SUCCESS { version })
-                    .await;
+                return result;
             }
+            self.analytics
+                .lock()
+                .await
+                .track_and_flush_silent(Event::INSTALL_VERSION_SUCCESS { version })
+                .await;
+            installs::rename_explorer_to_latest()?;
         }
 
-        installs::rename_explorer_to_latest()
+        StepResult::Ok(())
     }
 }
 

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -387,7 +387,8 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
                     version: version.clone(),
                 })
                 .await;
-            let result = Self::execute_internal(download);
+            let result = Self::execute_internal(download)
+                .and_then(|()| installs::rename_explorer_to_latest());
             if let Err(e) = &result {
                 self.analytics
                     .lock()
@@ -397,14 +398,14 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
                         error: e.to_string(),
                     })
                     .await;
-                return result;
+            } else {
+                self.analytics
+                    .lock()
+                    .await
+                    .track_and_flush_silent(Event::INSTALL_VERSION_SUCCESS { version })
+                    .await;
             }
-            self.analytics
-                .lock()
-                .await
-                .track_and_flush_silent(Event::INSTALL_VERSION_SUCCESS { version })
-                .await;
-            installs::rename_explorer_to_latest()?;
+            return result;
         }
 
         StepResult::Ok(())

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -384,7 +384,12 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
     // Windows `fs::rename` fails when a non-empty directory already exists at
     // the target, so wipe any stale build before extracting a fresh one.
     if branch_path.exists() {
-        fs::remove_dir_all(&branch_path)?;
+        fs::remove_dir_all(&branch_path).map_err(|source| {
+            StepError::E3005_STALE_BUILD_CLEANUP_FAILED {
+                path: branch_path.to_string_lossy().into_owned(),
+                source,
+            }
+        })?;
     }
     compression::decompress_file(&file_path, &branch_path)?;
 
@@ -425,15 +430,21 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         && latest_path.exists()
     {
         let target = explorer_path.join(&v);
+        let rename_back_err = |path: &Path, source: std::io::Error| {
+            StepError::E3006_RENAME_BACK_FAILED {
+                path: path.to_string_lossy().into_owned(),
+                source,
+            }
+        };
         if target == branch_path {
             // Reinstalling the same version: the fresh extract already
             // occupies `target`, so drop the stale copy at latest/.
-            fs::remove_dir_all(&latest_path)?;
+            fs::remove_dir_all(&latest_path).map_err(|e| rename_back_err(&latest_path, e))?;
         } else {
             if target.exists() {
-                fs::remove_dir_all(&target)?;
+                fs::remove_dir_all(&target).map_err(|e| rename_back_err(&target, e))?;
             }
-            fs::rename(&latest_path, &target)?;
+            fs::rename(&latest_path, &target).map_err(|e| rename_back_err(&latest_path, e))?;
         }
     }
 
@@ -450,7 +461,8 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
     let version_data_str =
         serde_json::to_string(&version_data).context("Cannot serialize version_data")?;
     let version_path = explorer_version_path();
-    fs::write(version_path, version_data_str)?;
+    fs::write(version_path, version_data_str)
+        .map_err(|source| StepError::E3007_VERSION_DATA_WRITE_FAILED { source })?;
 
     // Remove the downloaded file
     fs::remove_file(file_path)?;

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -381,6 +381,11 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         .into();
     }
 
+    // Windows `fs::rename` fails when a non-empty directory already exists at
+    // the target, so wipe any stale build before extracting a fresh one.
+    if branch_path.exists() {
+        fs::remove_dir_all(&branch_path)?;
+    }
     compression::decompress_file(&file_path, &branch_path)?;
 
     #[cfg(target_os = "macos")]
@@ -419,7 +424,17 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
     if let Ok(v) = latest_version
         && latest_path.exists()
     {
-        fs::rename(latest_path, explorer_path.join(v))?;
+        let target = explorer_path.join(&v);
+        if target == branch_path {
+            // Reinstalling the same version: the fresh extract already
+            // occupies `target`, so drop the stale copy at latest/.
+            fs::remove_dir_all(&latest_path)?;
+        } else {
+            if target.exists() {
+                fs::remove_dir_all(&target)?;
+            }
+            fs::rename(&latest_path, &target)?;
+        }
     }
 
     if version != "dev" {

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -366,6 +366,27 @@ pub fn target_download_path() -> PathBuf {
     explorer_downloads_path().join(EXPLORER_DOWNLOADED_FILENAME)
 }
 
+fn as_rename_back_err(path: &Path, source: std::io::Error) -> StepError {
+    StepError::E3006_RENAME_BACK_FAILED {
+        path: path.to_string_lossy().into_owned(),
+        source,
+    }
+}
+
+fn rename_latest_back_to_version(
+    latest_path: &Path,
+    target: &Path,
+    branch_path: &Path,
+) -> StepResult {
+    if target == branch_path {
+        return fs::remove_dir_all(latest_path).map_err(|e| as_rename_back_err(latest_path, e));
+    }
+    if target.exists() {
+        fs::remove_dir_all(target).map_err(|e| as_rename_back_err(target, e))?;
+    }
+    fs::rename(latest_path, target).map_err(|e| as_rename_back_err(latest_path, e))
+}
+
 pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) -> StepResult {
     let current_version: EntryVersion = EntryVersion::from_str(version)
         .ok_or_else(|| anyhow!("Version value cannot be parsed: {version}"))?;
@@ -381,8 +402,6 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         .into();
     }
 
-    // Windows `fs::rename` fails when a non-empty directory already exists at
-    // the target, so wipe any stale build before extracting a fresh one.
     if branch_path.exists() {
         fs::remove_dir_all(&branch_path).map_err(|source| {
             StepError::E3005_STALE_BUILD_CLEANUP_FAILED {
@@ -430,22 +449,7 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         && latest_path.exists()
     {
         let target = explorer_path.join(&v);
-        let rename_back_err = |path: &Path, source: std::io::Error| {
-            StepError::E3006_RENAME_BACK_FAILED {
-                path: path.to_string_lossy().into_owned(),
-                source,
-            }
-        };
-        if target == branch_path {
-            // Reinstalling the same version: the fresh extract already
-            // occupies `target`, so drop the stale copy at latest/.
-            fs::remove_dir_all(&latest_path).map_err(|e| rename_back_err(&latest_path, e))?;
-        } else {
-            if target.exists() {
-                fs::remove_dir_all(&target).map_err(|e| rename_back_err(&target, e))?;
-            }
-            fs::rename(&latest_path, &target).map_err(|e| rename_back_err(&latest_path, e))?;
-        }
+        rename_latest_back_to_version(&latest_path, &target, &branch_path)?;
     }
 
     if version != "dev" {


### PR DESCRIPTION
## Summary
Fixing https://decentraland.sentry.io/issues/7392650436/?project=4509072959012864&query=is%3Aunresolved&referrer=issue-stream

Fixing https://github.com/decentraland/unity-explorer/issues/8146

- `InstallStep::execute` dropped `install_explorer`'s error and always called `rename_explorer_to_latest`, which then failed on broken state and surfaced as `E3004_CANT_RENAME_LATEST` — masking the real cause. Now the install error is propagated and the rename only runs on success.
- `install_explorer` wipes `branch_path` before decompressing and handles two Windows `fs::rename` collisions in the rename-back step: reinstalling the same version (`target == branch_path`) and a stale rollback folder already occupying the target.

## Test plan
Windows
1. Install the launcher and let it download an explorer build. After it lands, %LOCALAPPDATA%\DecentralandLauncherLight\latest\ should exist with Decentraland.exe,  
  and version.json should have "version": "<X>" matching whatever's on S3.
  2. Quit the launcher.                                                                                                                                                
  3. Delete just latest\Decentraland.exe (or the whole latest\ if you want — but leave version.json alone). This simulates a corrupted/half-broken install.
  4. Relaunch the launcher.         