### PR TITLE
fix: activate explorer via Launch Services path instead of AppleScript name

### DIFF
--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -55,7 +55,7 @@ pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 /// Uses `open <path-to-.app>` so Launch Services activates the already-running
 /// instance by bundle id. We avoid `osascript tell application "Decentraland"`
 /// because the launcher itself is also named "Decentraland" and that
-/// AppleScript form resolves by display name, which is ambiguous.
+/// `AppleScript` form resolves by display name, which is ambiguous.
 #[cfg(target_os = "macos")]
 fn try_bring_explorer_to_front() {
     let app_path = match get_explorer_launch_path(None) {

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -7,10 +7,7 @@ use tokio::time::sleep;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::{
-    installs::{deeplink_bridge_path, get_explorer_launch_path},
-    protocols::DeepLink,
-};
+use crate::{installs::deeplink_bridge_path, protocols::DeepLink};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -55,7 +52,7 @@ pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 /// Keep it in mind using this function.
 #[cfg(target_os = "macos")]
 fn try_bring_explorer_to_front() {
-    let app_path = match get_explorer_launch_path(None) {
+    let app_path = match crate::installs::get_explorer_launch_path(None) {
         Ok(p) => p,
         Err(e) => {
             log::warn!("Failed to resolve Explorer .app path for activation: {e}");

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -7,7 +7,10 @@ use tokio::time::sleep;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::{installs::deeplink_bridge_path, protocols::DeepLink};
+use crate::{
+    installs::{deeplink_bridge_path, get_explorer_launch_path},
+    protocols::DeepLink,
+};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -48,17 +51,39 @@ impl From<std::io::Error> for PlaceDeeplinkError {
 pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 
 /// Best-effort attempt to bring the Explorer window to the front.
+///
+/// Uses `open <path-to-.app>` so Launch Services activates the already-running
+/// instance by bundle id. We avoid `osascript tell application "Decentraland"`
+/// because the launcher itself is also named "Decentraland" and that
+/// AppleScript form resolves by display name, which is ambiguous.
 #[cfg(target_os = "macos")]
 fn try_bring_explorer_to_front() {
-    let app_name = crate::installs::EXPLORER_MAC_APP_NAME;
-    let script = format!("tell application \"{app_name}\" to activate");
-    let result = std::process::Command::new("osascript")
-        .args(["-e", &script])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
-    if let Err(e) = result {
-        log::warn!("Failed to bring Explorer to front: {e}");
+    let app_path = match get_explorer_launch_path(None) {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("Failed to resolve Explorer .app path for activation: {e}");
+            return;
+        }
+    };
+
+    let output = std::process::Command::new("open").arg(&app_path).output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            log::info!("Activated Explorer at {}", app_path.display());
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            log::warn!(
+                "`open {}` exited with {}: {}",
+                app_path.display(),
+                out.status,
+                stderr.trim()
+            );
+        }
+        Err(e) => {
+            log::warn!("Failed to spawn `open` to activate Explorer: {e}");
+        }
     }
 }
 

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -69,8 +69,7 @@ fn try_bring_explorer_to_front() {
         Ok(out) => {
             if out.status.success() {
                 log::info!("Finish: Bring Explorer to front at {}", app_path.display());
-            }
-            else {
+            } else {
                 let stderr = String::from_utf8_lossy(&out.stderr);
                 log::warn!(
                     "`open {}` exited with {}: {}",
@@ -112,8 +111,7 @@ pub async fn place_deeplink_and_wait_until_consumed(
             () = sleep(Duration::from_millis(50)) => {
                 if !path.exists() {
 
-                    // Bring the Explorer window to the front only in case if the deeplink was
-                    // consumed
+                    // Bring the Explorer window to the front only in case if the deeplink was consumed
                     #[cfg(target_os = "macos")]
                     try_bring_explorer_to_front();
 

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -50,12 +50,9 @@ impl From<std::io::Error> for PlaceDeeplinkError {
 
 pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 
-/// Best-effort attempt to bring the Explorer window to the front.
-///
-/// Uses `open <path-to-.app>` so Launch Services activates the already-running
-/// instance by bundle id. We avoid `osascript tell application "Decentraland"`
-/// because the launcher itself is also named "Decentraland" and that
-/// `AppleScript` form resolves by display name, which is ambiguous.
+/// Uses `open <path-to-.app>` so Launch Services activates the already-running instance by bundle id.
+/// Since the function internally uses "open" command and if instance is not running then it may accidentally open new instance of the app.
+/// Keep it in mind using this function.
 #[cfg(target_os = "macos")]
 fn try_bring_explorer_to_front() {
     let app_path = match get_explorer_launch_path(None) {
@@ -69,20 +66,22 @@ fn try_bring_explorer_to_front() {
     let output = std::process::Command::new("open").arg(&app_path).output();
 
     match output {
-        Ok(out) if out.status.success() => {
-            log::info!("Activated Explorer at {}", app_path.display());
-        }
         Ok(out) => {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            log::warn!(
-                "`open {}` exited with {}: {}",
-                app_path.display(),
-                out.status,
-                stderr.trim()
-            );
+            if out.status.success() {
+                log::info!("Finish: Bring Explorer to front at {}", app_path.display());
+            }
+            else {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                log::warn!(
+                    "`open {}` exited with {}: {}",
+                    app_path.display(),
+                    out.status,
+                    stderr.trim()
+                );
+            }
         }
         Err(e) => {
-            log::warn!("Failed to spawn `open` to activate Explorer: {e}");
+            log::warn!("Failed to spawn `open` to Bring Explorer to front: {e}");
         }
     }
 }
@@ -102,10 +101,6 @@ pub async fn place_deeplink_and_wait_until_consumed(
         File::create(&path)?.write_all(json.as_bytes())?;
     }
 
-    // Bring the Explorer window to the front
-    #[cfg(target_os = "macos")]
-    try_bring_explorer_to_front();
-
     // Wait until file is deleted or operation is cancelled
     loop {
         tokio::select! {
@@ -116,6 +111,12 @@ pub async fn place_deeplink_and_wait_until_consumed(
             },
             () = sleep(Duration::from_millis(50)) => {
                 if !path.exists() {
+
+                    // Bring the Explorer window to the front only in case if the deeplink was
+                    // consumed
+                    #[cfg(target_os = "macos")]
+                    try_bring_explorer_to_front();
+
                     break;
                 }
             }

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -169,7 +169,7 @@ fn get_latest_version(version_data: &Map<String, Value>) -> Result<&str> {
         .ok_or_else(|| anyhow!(StepError::E3003_CANT_GET_VERSION.user_message()))
 }
 
-fn get_explorer_launch_path(version: Option<&str>) -> Result<PathBuf> {
+pub(crate) fn get_explorer_launch_path(version: Option<&str>) -> Result<PathBuf> {
     let base_path = match version {
         None => explorer_latest_version_path(),
         Some("dev") => explorer_dev_version_path(),


### PR DESCRIPTION
# fix: activate explorer via Launch Services path instead of AppleScript name

## Summary
- Replaces `osascript tell application "Decentraland" to activate` with `open <path-to-.app>` in the deeplink focus flow.
- The previous form resolved the target by display name. Because the launcher itself is also named `Decentraland` (`tauri.conf.json` `productName`), AppleScript could activate the launcher rather than the explorer — and any explorer-side display-name change (e.g. window title `Explorer`) would break it outright.
- `open <path>` makes Launch Services resolve by `CFBundleIdentifier`, which is stable and independent of display name. The .app path is resolved at runtime via `get_explorer_launch_path(None)`.
- Captures stderr from `open` and logs success/failure so silent breakage is visible next time.

## Test plan
- [ ] With Decentraland Explorer already open, click a `decentraland://` deeplink in the browser and confirm the launcher shows "Opening DeepLink" briefly and the existing Explorer window is brought to the front (no second instance).
- [ ] Confirm `open ~/Library/Application\ Support/DecentralandLauncherLight/latest/Decentraland.app` activates the running explorer when run from a terminal.
- [ ] Confirm the cold-start path (Explorer not running) still launches a new instance via the existing `launch_explorer` path.
- [ ] Verify launcher logs include "Activated Explorer at ..." on success, or a warning with the `open` exit status / stderr on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
