### PR TITLE
chore: improve grouping of version.json error

### DIFF
--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -144,9 +144,7 @@ fn get_version_data() -> Result<Map<String, Value>> {
 
 fn get_version_data_or_empty() -> Map<String, Value> {
     get_version_data().unwrap_or_else(|_e| {
-        log::error!(
-            "Cannot get version data, fallback to new empty: File doesn't exist: version.json"
-        );
+        log::error!("Cannot get version data, fallback to new empty");
 
         Map::new()
     })

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -143,9 +143,9 @@ fn get_version_data() -> Result<Map<String, Value>> {
 }
 
 fn get_version_data_or_empty() -> Map<String, Value> {
-    get_version_data().unwrap_or_else(|e| {
+    get_version_data().unwrap_or_else(|_e| {
         log::error!(
-            "Cannot get version data, fallback to new empty: File doesn't exist: version.json: {e}"
+            "Cannot get version data, fallback to new empty: File doesn't exist: version.json"
         );
 
         Map::new()


### PR DESCRIPTION
The dynamic file path in the log message broke Sentry grouping. Originally fixed in #165, inadvertently reverted in #209.