### PR TITLE
feat: extract anon_user_id from installer filename as Zone.Identifier fallback

### DIFF
--- a/src-auto-auth/Cargo.lock
+++ b/src-auto-auth/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "dcl-launcher-core"
-version = "1.12.8"
+version = "1.14.4"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.1",
@@ -2116,9 +2116,10 @@ dependencies = [
 
 [[package]]
 name = "src-auto-auth"
-version = "1.12.8"
+version = "1.14.4"
 dependencies = [
  "dcl-launcher-core",
+ "regex",
  "rstest",
  "windows-sys 0.59.0",
 ]

--- a/src-auto-auth/Cargo.toml
+++ b/src-auto-auth/Cargo.toml
@@ -16,6 +16,7 @@ panic = "abort" # Higher performance by disabling panic handlers.
 strip = "symbols" # Ensures debug symbols are removed.
 
 [dependencies]
+regex = "1.11.1"
 rstest = "0.26.1"
 
 [dependencies.dcl-launcher-core]

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -112,7 +112,9 @@ fn extract_anon_user_id_from_filename(installer_path: &str) -> Option<AnonUserId
     let stem = Path::new(installer_path).file_stem()?.to_str()?;
     let after_prefix = stem.strip_prefix(INSTALLER_FILENAME_PREFIX)?;
     // Strip the browser's " (n)" dedup suffix if present.
-    let cleaned = after_prefix.split(" (").next().unwrap_or(after_prefix);
+    let cleaned = after_prefix
+        .split_once(" (")
+        .map_or(after_prefix, |(before, _)| before);
     AnonUserId::parse(cleaned)
 }
 

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -1,6 +1,8 @@
 // Avoid popup terminal window
 #![windows_subsystem = "windows"]
 
+use std::path::Path;
+
 use dcl_launcher_core::{
     anyhow::{Context, Result, anyhow},
     auto_auth::anon_user_id::AnonUserId,
@@ -8,6 +10,12 @@ use dcl_launcher_core::{
     auto_auth::campaign_anon_user_id_storage::CampaignAnonUserIdStorage,
     log, logs,
 };
+
+/// Filename prefix the download gateway uses when serving the anonymous EXE.
+/// The full filename is `<INSTALLER_FILENAME_PREFIX><UUID>.exe` (with an
+/// optional ` (n)` suffix added by the browser when deduplicating downloads
+/// in the user's Downloads folder).
+const INSTALLER_FILENAME_PREFIX: &str = "Decentraland-Installer-";
 
 #[derive(Debug, Default)]
 pub struct ZoneInfo {
@@ -44,8 +52,18 @@ fn main_internal() -> Result<()> {
         if let Err(e) = CampaignAnonUserIdStorage::write(&anon_id) {
             log::error!("Cannot write campaign anon user id: {e}");
         }
+    } else if let Some(anon_id) = extract_anon_user_id_from_filename(installer_path) {
+        // Fallback for the anonymous Download First flow on Windows: the
+        // gateway encodes the UUID in the Content-Disposition filename so
+        // attribution survives Windows' silent-unblock-on-launch handling
+        // (which strips the Zone.Identifier ADS for trusted signed binaries
+        // before this script runs).
+        log::info!("Campaign anon_user_id extracted from filename");
+        if let Err(e) = CampaignAnonUserIdStorage::write(&anon_id) {
+            log::error!("Cannot write campaign anon user id: {e}");
+        }
     } else {
-        log::info!("No campaign anon_user_id found in Zone.Identifier URLs");
+        log::info!("No campaign anon_user_id found in Zone.Identifier URLs or installer filename");
     }
 
     if AuthTokenStorage::has_token() {
@@ -78,6 +96,24 @@ fn extract_anon_user_id_from_zone(installer_path: &str) -> Option<AnonUserId> {
         .into_iter()
         .flatten()
         .find_map(AnonUserId::from_url)
+}
+
+/// Try to extract `anon_user_id` from the installer's filename.
+///
+/// The download gateway names anonymous EXE downloads
+/// `Decentraland-Installer-<UUID>.exe`. When the user already has a file with
+/// the same name in `Downloads`, browsers append a ` (n)` dedup suffix
+/// (e.g. `Decentraland-Installer-<UUID> (3).exe`); we tolerate that.
+///
+/// This is the fallback path used when Zone.Identifier has been stripped by
+/// Windows' silent-unblock handling for trusted signed binaries — which is
+/// the steady-state for popular pre-signed installers and not an edge case.
+fn extract_anon_user_id_from_filename(installer_path: &str) -> Option<AnonUserId> {
+    let stem = Path::new(installer_path).file_stem()?.to_str()?;
+    let after_prefix = stem.strip_prefix(INSTALLER_FILENAME_PREFIX)?;
+    // Strip the browser's " (n)" dedup suffix if present.
+    let cleaned = after_prefix.split(" (").next().unwrap_or(after_prefix);
+    AnonUserId::parse(cleaned)
 }
 
 // Zone.Identifier
@@ -407,5 +443,58 @@ mod tests {
         let token = token_from_zone_info(zone)?;
         assert_eq!(expected_token, token.as_str());
         Ok(())
+    }
+
+    // Tests use forward-slash paths so they run on both Windows and Unix CI
+    // hosts. `Path::file_stem` uses the host OS's path semantics, but the
+    // production code targets Windows where `\` and `/` both work as
+    // separators — and we only need to exercise the parsing logic here, not
+    // the OS path resolution.
+    #[rstest]
+    #[case(
+        "Downloads/Decentraland-Installer-391a85da-a3bb-49e2-a45e-96c740c38424.exe",
+        Some("391a85da-a3bb-49e2-a45e-96c740c38424")
+    )]
+    #[case(
+        // Bare filename, no parent directory.
+        "Decentraland-Installer-391a85da-a3bb-49e2-a45e-96c740c38424.exe",
+        Some("391a85da-a3bb-49e2-a45e-96c740c38424")
+    )]
+    #[case(
+        // Browser dedup suffix when the file already exists in Downloads.
+        "Decentraland-Installer-391a85da-a3bb-49e2-a45e-96c740c38424 (3).exe",
+        Some("391a85da-a3bb-49e2-a45e-96c740c38424")
+    )]
+    #[case(
+        // Different valid UUID, slash-prefixed absolute path.
+        "/tmp/Decentraland-Installer-62792c33-59e3-4e7f-be42-289c053ecb37.exe",
+        Some("62792c33-59e3-4e7f-be42-289c053ecb37")
+    )]
+    #[case(
+        // Old-style filename (no UUID) → no fallback match, the caller must
+        // treat this as "no anon_user_id available".
+        "Decentraland-Installer.exe",
+        None
+    )]
+    #[case(
+        // Wrong prefix (different launcher build) → no match.
+        "some-other-installer-391a85da-a3bb-49e2-a45e-96c740c38424.exe",
+        None
+    )]
+    #[case(
+        // Prefix matches but the UUID part contains a character AnonUserId
+        // rejects (raw space). Defends against malformed filenames written by
+        // an attacker who controls the download URL.
+        "Decentraland-Installer-not a uuid.exe",
+        None
+    )]
+    #[case(
+        // Empty stem (impossible in practice, but we should not panic).
+        "",
+        None
+    )]
+    fn test_extract_anon_user_id_from_filename(#[case] path: &str, #[case] expected: Option<&str>) {
+        let actual = extract_anon_user_id_from_filename(path);
+        assert_eq!(expected, actual.as_ref().map(|id| id.as_str()));
     }
 }

--- a/src-auto-auth/src/main.rs
+++ b/src-auto-auth/src/main.rs
@@ -10,12 +10,7 @@ use dcl_launcher_core::{
     auto_auth::campaign_anon_user_id_storage::CampaignAnonUserIdStorage,
     log, logs,
 };
-
-/// Filename prefix the download gateway uses when serving the anonymous EXE.
-/// The full filename is `<INSTALLER_FILENAME_PREFIX><UUID>.exe` (with an
-/// optional ` (n)` suffix added by the browser when deduplicating downloads
-/// in the user's Downloads folder).
-const INSTALLER_FILENAME_PREFIX: &str = "Decentraland-Installer-";
+use regex::Regex;
 
 #[derive(Debug, Default)]
 pub struct ZoneInfo {
@@ -101,21 +96,29 @@ fn extract_anon_user_id_from_zone(installer_path: &str) -> Option<AnonUserId> {
 /// Try to extract `anon_user_id` from the installer's filename.
 ///
 /// The download gateway names anonymous EXE downloads
-/// `Decentraland-Installer-<UUID>.exe`. When the user already has a file with
-/// the same name in `Downloads`, browsers append a ` (n)` dedup suffix
-/// (e.g. `Decentraland-Installer-<UUID> (3).exe`); we tolerate that.
+/// `Decentraland-Installer-<UUID>.exe`. The regex matches any RFC 4122 UUID
+/// embedded in the filename so we tolerate browser-added suffixes (e.g.
+/// `Decentraland-Installer-<UUID> (3).exe` for dedup) and don't lock the
+/// launcher to a specific gateway-side filename convention.
 ///
 /// This is the fallback path used when Zone.Identifier has been stripped by
 /// Windows' silent-unblock handling for trusted signed binaries — which is
 /// the steady-state for popular pre-signed installers and not an edge case.
 fn extract_anon_user_id_from_filename(installer_path: &str) -> Option<AnonUserId> {
-    let stem = Path::new(installer_path).file_stem()?.to_str()?;
-    let after_prefix = stem.strip_prefix(INSTALLER_FILENAME_PREFIX)?;
-    // Strip the browser's " (n)" dedup suffix if present.
-    let cleaned = after_prefix
-        .split_once(" (")
-        .map_or(after_prefix, |(before, _)| before);
-    AnonUserId::parse(cleaned)
+    let file_name = Path::new(installer_path).file_name()?.to_str()?;
+
+    let re = match Regex::new(
+        r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("Regex compile error (anon_user_id extraction): {e}");
+            return None;
+        }
+    };
+
+    let m = re.find(file_name)?;
+    AnonUserId::parse(m.as_str())
 }
 
 // Zone.Identifier
@@ -479,16 +482,30 @@ mod tests {
         None
     )]
     #[case(
-        // Wrong prefix (different launcher build) → no match.
+        // Different surrounding context — the regex finds the UUID anywhere
+        // in the filename, so the parser stays decoupled from the gateway's
+        // exact filename convention.
         "some-other-installer-391a85da-a3bb-49e2-a45e-96c740c38424.exe",
+        Some("391a85da-a3bb-49e2-a45e-96c740c38424")
+    )]
+    #[case(
+        // Prefix matches but the UUID part is malformed (raw space). The
+        // RFC 4122 regex rejects it. Defends against attacker-controlled
+        // filenames.
+        "Decentraland-Installer-not a uuid.exe",
         None
     )]
     #[case(
-        // Prefix matches but the UUID part contains a character AnonUserId
-        // rejects (raw space). Defends against malformed filenames written by
-        // an attacker who controls the download URL.
-        "Decentraland-Installer-not a uuid.exe",
+        // Wrong variant bits (third group does not start with 1-5). RFC 4122
+        // strict regex rejects, even though AnonUserId::parse alone would
+        // accept the alphanumeric+hyphen string.
+        "Decentraland-Installer-391a85da-a3bb-09e2-a45e-96c740c38424.exe",
         None
+    )]
+    #[case(
+        // Uppercase hex still matches thanks to the (?i) flag.
+        "Decentraland-Installer-391A85DA-A3BB-49E2-A45E-96C740C38424.exe",
+        Some("391A85DA-A3BB-49E2-A45E-96C740C38424")
     )]
     #[case(
         // Empty stem (impossible in practice, but we should not panic).


### PR DESCRIPTION
`src-auto-auth` now tries to extract the campaign UUID from the installer's filename (\`Decentraland-Installer-<UUID>.exe\`) when the Zone.Identifier ADS is  unavailable. Zone.Identifier remains the primary path; filename is the fallback. The fallback is necessary because Windows silently unblocks trusted signed binaries on launch (high-rep hash + EV cert) and that handling strips the Zone.Identifier ADS before this script can read it — exactly the path triggered when the download gateway serves the same pre-signed binary to all users (the perf optimization that motivates this PR). Tolerates the \" (n)\" dedup suffix browsers add when the same filename already exists in Downloads. Pairs with client-download-gateway feat/anon-uuid-in-filename.