### PR TITLE
feat: emit device fingerprint signals on every analytics event

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +104,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -106,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -260,19 +284,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
 name = "dcl-launcher-core"
-version = "1.12.11"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "deranged",
  "dirs",
+ "display-info",
  "fern",
  "flate2",
  "futures-util",
  "get_if_addrs",
  "humantime",
+ "iana-time-zone",
  "libc",
  "log",
  "nix",
@@ -290,6 +322,7 @@ dependencies = [
  "sentry-types",
  "serde",
  "serde_json",
+ "sys-locale",
  "sysinfo",
  "system-configuration",
  "tar",
@@ -374,6 +407,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+]
+
+[[package]]
+name = "display-info"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0aca670967c2528799e316f9f97913efcc034867614d55681dd41a1c2f7830"
+dependencies = [
+ "fxhash",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "scopeguard",
+ "smithay-client-toolkit",
+ "thiserror 2.0.12",
+ "widestring",
+ "windows 0.62.0",
+ "xcb",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +447,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "env_logger"
@@ -577,6 +647,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -831,6 +910,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,9 +1141,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1048,7 +1151,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall",
 ]
@@ -1075,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1135,6 +1238,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,7 +1295,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1205,12 +1317,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17614fdcd9b411e6ff1117dfb1d0150f908ba83a7df81b1f118005fe0a8ea15d"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291fbbf7d29287518e8686417cf7239c74700fd4b607623140a7d4a3c834329d"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b3dc0cc4386b6ccf21c157591b34a7f44c8e75b064f85502901ab2188c007e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1221,6 +1432,39 @@ checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f246c183239540aab1782457b35ab2040d4259175bd1d0c58e46ada7b47a874"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ffb6a0cd5f182dc964334388560b12a57f7b74b3e2dec5e2722aa2dfb2ccd5"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1244,7 +1488,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1364,7 +1608,7 @@ checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.32.0",
  "serde",
  "time",
 ]
@@ -1414,9 +1658,27 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -1556,7 +1818,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1703,7 +1965,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1734,11 +1996,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1822,7 +2084,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2095,6 +2357,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.9.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix",
+ "thiserror 2.0.12",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,7 +2463,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2669,6 +2965,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.9.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.9.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,6 +3110,12 @@ checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -2750,11 +3170,24 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
- "windows-link",
- "windows-numerics",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+dependencies = [
+ "windows-collections 0.3.0",
+ "windows-core 0.62.0",
+ "windows-future 0.3.0",
+ "windows-link 0.2.1",
+ "windows-numerics 0.3.0",
 ]
 
 [[package]]
@@ -2764,6 +3197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+dependencies = [
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -2783,9 +3225,22 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -2795,8 +3250,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
- "windows-threading",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
+dependencies = [
+ "windows-core 0.62.0",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -2828,13 +3294,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+dependencies = [
+ "windows-core 0.62.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2843,7 +3325,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result",
+ "windows-result 0.3.4",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
@@ -2854,7 +3336,16 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2863,7 +3354,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2872,7 +3363,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2955,7 +3455,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3111,7 +3620,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3135,6 +3644,29 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xz2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,6 +69,12 @@ sentry-types = "0.37.0"
 
 get_if_addrs = "0.5.3"
 
+# Stable device signals for the cross-source attribution join with
+# landing-site Segment events. See analytics/fingerprint.rs.
+display-info = "0.5"
+iana-time-zone = "0.1"
+sys-locale = "0.3"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 system-configuration = "0.6.1"
 rusqlite = { version = "0.37.0" }

--- a/core/src/analytics.rs
+++ b/core/src/analytics.rs
@@ -1,5 +1,6 @@
 mod client;
 pub mod event;
+mod fingerprint;
 mod network_info;
 mod null_client;
 mod session;

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
-use log::{error, info, warn};
+use log::{error, info};
 use segment::HttpClient;
 use segment::message::{Track, User};
 use segment::queue::event_queue::{
@@ -59,7 +59,7 @@ impl AnalyticsClient {
             launcher_version,
             campaign_anon_user_id: None,
             session_id,
-            fingerprint_props: serialize_fingerprint(&ClientFingerprint::collect()),
+            fingerprint_props: ClientFingerprint::current().into(),
             batcher,
             send_daemon,
         }
@@ -154,26 +154,6 @@ impl AnalyticsClient {
     }
 }
 
-// Serialize the fingerprint snapshot once at client construction time so
-// every subsequent `track()` call can merge a pre-built map instead of
-// re-serializing the same struct. A serialization failure here would
-// indicate a programmer error in `ClientFingerprint` (it's a plain struct
-// of primitives), so we degrade to an empty map and log a warning rather
-// than failing the analytics client startup.
-fn serialize_fingerprint(fp: &ClientFingerprint) -> Map<String, Value> {
-    match serde_json::to_value(fp) {
-        Ok(Value::Object(map)) => map,
-        Ok(other) => {
-            warn!("ClientFingerprint serialized to non-object value: {other}");
-            Map::new()
-        }
-        Err(e) => {
-            warn!("Cannot serialize ClientFingerprint, dropping fingerprint fields: {e}");
-            Map::new()
-        }
-    }
-}
-
 // Per-event properties win over the static defaults so a caller that wants
 // to override an individual field (e.g. for a synthetic event) keeps that
 // override without having to repeat the rest of the fingerprint.
@@ -250,21 +230,27 @@ mod tests {
     #[test]
     fn merge_static_defaults_preserves_per_event_properties() {
         let mut properties = Map::new();
-        properties.insert("platform".to_owned(), Value::String("override".to_owned()));
+        properties.insert("fp_platform".to_owned(), Value::String("override".to_owned()));
 
         let mut defaults = Map::new();
-        defaults.insert("platform".to_owned(), Value::String("macos/aarch64".to_owned()));
-        defaults.insert("hardware_concurrency".to_owned(), Value::from(8u32));
+        defaults.insert(
+            "fp_platform".to_owned(),
+            Value::String("macos/aarch64".to_owned()),
+        );
+        defaults.insert("fp_hardware_concurrency".to_owned(), Value::from(8u32));
 
         merge_static_defaults(&mut properties, &defaults);
 
         // Caller-supplied value wins.
         assert_eq!(
-            properties.get("platform"),
+            properties.get("fp_platform"),
             Some(&Value::String("override".to_owned()))
         );
         // Missing keys are filled in from the defaults.
-        assert_eq!(properties.get("hardware_concurrency"), Some(&Value::from(8u32)));
+        assert_eq!(
+            properties.get("fp_hardware_concurrency"),
+            Some(&Value::from(8u32))
+        );
     }
 
     #[test]

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
-use log::{error, info};
+use log::{error, info, warn};
 use segment::HttpClient;
 use segment::message::{Track, User};
 use segment::queue::event_queue::{
@@ -29,7 +29,7 @@ pub struct AnalyticsClient {
     launcher_version: String,
     campaign_anon_user_id: Option<String>,
     session_id: SessionId,
-    fingerprint: ClientFingerprint,
+    fingerprint_props: Map<String, Value>,
     batcher: QueuedBatcher,
     send_daemon: AnalyticsEventSendDaemon<HttpClient>,
 }
@@ -59,7 +59,7 @@ impl AnalyticsClient {
             launcher_version,
             campaign_anon_user_id: None,
             session_id,
-            fingerprint: ClientFingerprint::collect(),
+            fingerprint_props: serialize_fingerprint(&ClientFingerprint::collect()),
             batcher,
             send_daemon,
         }
@@ -89,13 +89,7 @@ impl AnalyticsClient {
             );
         }
 
-        // Per-event properties win over the fingerprint defaults so callers
-        // can override individual fields without losing the rest.
-        if let Ok(Value::Object(fp_map)) = serde_json::to_value(&self.fingerprint) {
-            for (k, v) in fp_map {
-                properties.entry(k).or_insert(v);
-            }
-        }
+        merge_static_defaults(&mut properties, &self.fingerprint_props);
 
         let user = User::AnonymousId {
             anonymous_id: self.anonymous_id.clone(),
@@ -157,6 +151,35 @@ impl AnalyticsClient {
         self.send_daemon
             .wait_until_empty_queue_or_abandon(None)
             .await;
+    }
+}
+
+// Serialize the fingerprint snapshot once at client construction time so
+// every subsequent `track()` call can merge a pre-built map instead of
+// re-serializing the same struct. A serialization failure here would
+// indicate a programmer error in `ClientFingerprint` (it's a plain struct
+// of primitives), so we degrade to an empty map and log a warning rather
+// than failing the analytics client startup.
+fn serialize_fingerprint(fp: &ClientFingerprint) -> Map<String, Value> {
+    match serde_json::to_value(fp) {
+        Ok(Value::Object(map)) => map,
+        Ok(other) => {
+            warn!("ClientFingerprint serialized to non-object value: {other}");
+            Map::new()
+        }
+        Err(e) => {
+            warn!("Cannot serialize ClientFingerprint, dropping fingerprint fields: {e}");
+            Map::new()
+        }
+    }
+}
+
+// Per-event properties win over the static defaults so a caller that wants
+// to override an individual field (e.g. for a synthetic event) keeps that
+// override without having to repeat the rest of the fingerprint.
+fn merge_static_defaults(properties: &mut Map<String, Value>, defaults: &Map<String, Value>) {
+    for (k, v) in defaults {
+        properties.entry(k.clone()).or_insert_with(|| v.clone());
     }
 }
 
@@ -223,6 +246,26 @@ fn new_event_queue() -> CombinedAnalyticsEventQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn merge_static_defaults_preserves_per_event_properties() {
+        let mut properties = Map::new();
+        properties.insert("platform".to_owned(), Value::String("override".to_owned()));
+
+        let mut defaults = Map::new();
+        defaults.insert("platform".to_owned(), Value::String("macos/aarch64".to_owned()));
+        defaults.insert("hardware_concurrency".to_owned(), Value::from(8u32));
+
+        merge_static_defaults(&mut properties, &defaults);
+
+        // Caller-supplied value wins.
+        assert_eq!(
+            properties.get("platform"),
+            Some(&Value::String("override".to_owned()))
+        );
+        // Missing keys are filled in from the defaults.
+        assert_eq!(properties.get("hardware_concurrency"), Some(&Value::from(8u32)));
+    }
 
     #[test]
     fn context_attachments() -> Result<()> {

--- a/core/src/analytics/client.rs
+++ b/core/src/analytics/client.rs
@@ -18,6 +18,7 @@ use crate::analytics::network_info::network_context;
 use crate::environment::AppEnvironment;
 
 use super::event::Event;
+use super::fingerprint::ClientFingerprint;
 use super::session::SessionId;
 
 const APP_ID: &str = "decentraland-launcher-rust";
@@ -28,6 +29,7 @@ pub struct AnalyticsClient {
     launcher_version: String,
     campaign_anon_user_id: Option<String>,
     session_id: SessionId,
+    fingerprint: ClientFingerprint,
     batcher: QueuedBatcher,
     send_daemon: AnalyticsEventSendDaemon<HttpClient>,
 }
@@ -57,6 +59,7 @@ impl AnalyticsClient {
             launcher_version,
             campaign_anon_user_id: None,
             session_id,
+            fingerprint: ClientFingerprint::collect(),
             batcher,
             send_daemon,
         }
@@ -84,6 +87,14 @@ impl AnalyticsClient {
                 "campaign_anon_user_id".to_owned(),
                 Value::String(anon_id.clone()),
             );
+        }
+
+        // Per-event properties win over the fingerprint defaults so callers
+        // can override individual fields without losing the rest.
+        if let Ok(Value::Object(fp_map)) = serde_json::to_value(&self.fingerprint) {
+            for (k, v) in fp_map {
+                properties.entry(k).or_insert(v);
+            }
         }
 
         let user = User::AnonymousId {

--- a/core/src/analytics/fingerprint.rs
+++ b/core/src/analytics/fingerprint.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use serde::Serialize;
 
 // Cross-source attribution join with landing-site Segment events relies on
@@ -13,7 +14,12 @@ pub struct ClientFingerprint {
     screen_width: u32,
     screen_height: u32,
     device_pixel_ratio: f64,
-    color_depth: u32,
+    // `display-info` doesn't expose bit depth on any platform we ship to,
+    // so the launcher omits the field entirely instead of emitting a
+    // constant that would only confuse the warehouse join. The
+    // landing-site side keeps reporting it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color_depth: Option<u32>,
     hardware_concurrency: u32,
     timezone: String,
     language: String,
@@ -27,7 +33,7 @@ impl ClientFingerprint {
             screen_width: display.width,
             screen_height: display.height,
             device_pixel_ratio: display.scale_factor,
-            color_depth: display.color_depth,
+            color_depth: None,
             hardware_concurrency: hardware_concurrency(),
             timezone: timezone_name(),
             language: locale(),
@@ -40,7 +46,6 @@ struct DisplaySnapshot {
     width: u32,
     height: u32,
     scale_factor: f64,
-    color_depth: u32,
 }
 
 impl Default for DisplaySnapshot {
@@ -49,14 +54,19 @@ impl Default for DisplaySnapshot {
             width: 0,
             height: 0,
             scale_factor: 1.0,
-            color_depth: 0,
         }
     }
 }
 
 fn primary_display_info() -> DisplaySnapshot {
-    let Ok(displays) = display_info::DisplayInfo::all() else {
-        return DisplaySnapshot::default();
+    let displays = match display_info::DisplayInfo::all() {
+        Ok(d) => d,
+        Err(e) => {
+            // Real desktops shouldn't hit this; CI and headless RDP do.
+            // Debug level keeps it visible without noisy warnings.
+            debug!("display-info probe failed, defaulting screen fields: {e}");
+            return DisplaySnapshot::default();
+        }
     };
 
     let chosen = displays
@@ -69,10 +79,6 @@ fn primary_display_info() -> DisplaySnapshot {
             width: d.width,
             height: d.height,
             scale_factor: f64::from(d.scale_factor),
-            // `display-info` doesn't expose bit depth on every platform.
-            // Modern displays are 24- or 32-bit; pinning to 24 keeps the
-            // schema parity with the browser-side payload.
-            color_depth: 24,
         },
         None => DisplaySnapshot::default(),
     }
@@ -101,18 +107,18 @@ fn platform_string() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::{Result, anyhow};
 
     #[test]
-    fn collect_produces_a_serializable_snapshot_with_every_field() {
+    fn collect_produces_a_serializable_snapshot_with_every_field() -> Result<()> {
         let fp = ClientFingerprint::collect();
-        let value = serde_json::to_value(&fp).expect("serializable");
-        let obj = value.as_object().expect("object");
+        let value = serde_json::to_value(&fp)?;
+        let obj = value.as_object().ok_or_else(|| anyhow!("not an object"))?;
 
         for key in [
             "screen_width",
             "screen_height",
             "device_pixel_ratio",
-            "color_depth",
             "hardware_concurrency",
             "timezone",
             "language",
@@ -120,15 +126,22 @@ mod tests {
         ] {
             assert!(obj.contains_key(key), "missing field: {key}");
         }
+        // `color_depth` is intentionally omitted when not available
+        // (always, on current launcher targets) thanks to `skip_serializing_if`.
+        assert!(!obj.contains_key("color_depth"));
+        Ok(())
     }
 
     #[test]
-    fn platform_string_includes_os_and_arch_separated_by_slash() {
+    fn platform_string_includes_os_and_arch_separated_by_slash() -> Result<()> {
         let platform = platform_string();
         let parts: Vec<&str> = platform.split('/').collect();
         assert_eq!(parts.len(), 2, "expected os/arch, got {platform}");
-        assert!(!parts[0].is_empty());
-        assert!(!parts[1].is_empty());
+        let os = parts.first().ok_or_else(|| anyhow!("missing os part"))?;
+        let arch = parts.get(1).ok_or_else(|| anyhow!("missing arch part"))?;
+        assert!(!os.is_empty());
+        assert!(!arch.is_empty());
+        Ok(())
     }
 
     #[test]

--- a/core/src/analytics/fingerprint.rs
+++ b/core/src/analytics/fingerprint.rs
@@ -1,43 +1,59 @@
+use std::sync::LazyLock;
+
 use log::debug;
 use serde::Serialize;
+use serde_json::{Map, Value};
 
 // Cross-source attribution join with landing-site Segment events relies on
-// these field names and shapes matching `landing-site/src/modules/fingerprint.ts`
-// exactly. `timezone_offset_minutes` (sent by the browser) is intentionally
-// not mirrored here: `time::OffsetDateTime::now_local()` requires the
+// these field names and shapes matching the landing-site fingerprint module
+// exactly. See:
+//   https://github.com/decentraland/landing-site/blob/main/src/modules/fingerprint.ts
+//
+// `timezone_offset_minutes` (sent by the browser) is intentionally not
+// mirrored here: `time::OffsetDateTime::now_local()` requires the
 // `local-offset` feature and returns `Err` from inside the tokio runtime
-// for soundness reasons. The IANA `timezone` field is more useful anyway —
-// the data warehouse can derive the offset from the timezone + event
+// for soundness reasons. The IANA `fp_timezone` field is more useful anyway
+// — the data warehouse can derive the offset from the timezone + event
 // timestamp at join time.
+// `fp_` prefix keeps these fields from colliding with caller-supplied
+// property names when merged into a Segment event payload.
+#[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone, Serialize)]
 pub struct ClientFingerprint {
-    screen_width: u32,
-    screen_height: u32,
-    device_pixel_ratio: f64,
-    // `display-info` doesn't expose bit depth on any platform we ship to,
-    // so the launcher omits the field entirely instead of emitting a
-    // constant that would only confuse the warehouse join. The
-    // landing-site side keeps reporting it.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    color_depth: Option<u32>,
-    hardware_concurrency: u32,
-    timezone: String,
-    language: String,
-    platform: String,
+    fp_screen_width: u32,
+    fp_screen_height: u32,
+    fp_device_pixel_ratio: f64,
+    fp_hardware_concurrency: Option<u32>,
+    fp_timezone: Option<String>,
+    fp_language: Option<String>,
+    fp_platform: &'static str,
 }
 
 impl ClientFingerprint {
-    pub fn collect() -> Self {
+    pub fn current() -> Self {
         let display = primary_display_info();
         Self {
-            screen_width: display.width,
-            screen_height: display.height,
-            device_pixel_ratio: display.scale_factor,
-            color_depth: None,
-            hardware_concurrency: hardware_concurrency(),
-            timezone: timezone_name(),
-            language: locale(),
-            platform: platform_string(),
+            fp_screen_width: display.width,
+            fp_screen_height: display.height,
+            fp_device_pixel_ratio: display.scale_factor,
+            fp_hardware_concurrency: hardware_concurrency(),
+            fp_timezone: iana_time_zone::get_timezone().ok(),
+            fp_language: sys_locale::get_locale(),
+            fp_platform: PLATFORM.as_str(),
+        }
+    }
+}
+
+#[allow(clippy::fallible_impl_from)]
+impl From<ClientFingerprint> for Map<String, Value> {
+    #[allow(clippy::unwrap_used)]
+    fn from(value: ClientFingerprint) -> Self {
+        // Infallible by construction: a `#[derive(Serialize)]` struct of
+        // plain fields always serializes to a JSON Object. Anything else
+        // would be a compile-time bug in this module.
+        match serde_json::to_value(value).unwrap() {
+            Value::Object(map) => map,
+            _ => unreachable!(),
         }
     }
 }
@@ -84,25 +100,22 @@ fn primary_display_info() -> DisplaySnapshot {
     }
 }
 
-fn hardware_concurrency() -> u32 {
+// `available_parallelism` returns `NonZero<usize>`; map to `u32` and surface
+// `None` if the probe fails (locked-down CI / containers) rather than
+// emitting a misleading zero or a fabricated default.
+fn hardware_concurrency() -> Option<u32> {
     std::thread::available_parallelism()
-        .map(|n| u32::try_from(n.get()).unwrap_or(u32::MAX))
-        .unwrap_or(0)
+        .ok()
+        .and_then(|n| u32::try_from(n.get()).ok())
 }
 
-fn timezone_name() -> String {
-    iana_time_zone::get_timezone().unwrap_or_default()
-}
-
-fn locale() -> String {
-    sys_locale::get_locale().unwrap_or_default()
-}
-
-// Includes the arch so multi-arch builds (Apple Silicon vs Intel, ARM
-// Windows) are distinguishable: e.g. "macos/aarch64", "windows/x86_64".
-fn platform_string() -> String {
+// `concat!` only accepts literal tokens, so we resolve the constants via
+// `LazyLock` once on first access instead. Includes the arch so multi-arch
+// builds (Apple Silicon vs Intel, ARM Windows) are distinguishable:
+// e.g. "macos/aarch64", "windows/x86_64".
+static PLATFORM: LazyLock<String> = LazyLock::new(|| {
     format!("{}/{}", std::env::consts::OS, std::env::consts::ARCH)
-}
+});
 
 #[cfg(test)]
 mod tests {
@@ -110,31 +123,28 @@ mod tests {
     use anyhow::{Result, anyhow};
 
     #[test]
-    fn collect_produces_a_serializable_snapshot_with_every_field() -> Result<()> {
-        let fp = ClientFingerprint::collect();
+    fn current_produces_a_serializable_snapshot_with_expected_fields() -> Result<()> {
+        let fp = ClientFingerprint::current();
         let value = serde_json::to_value(&fp)?;
         let obj = value.as_object().ok_or_else(|| anyhow!("not an object"))?;
 
         for key in [
-            "screen_width",
-            "screen_height",
-            "device_pixel_ratio",
-            "hardware_concurrency",
-            "timezone",
-            "language",
-            "platform",
+            "fp_screen_width",
+            "fp_screen_height",
+            "fp_device_pixel_ratio",
+            "fp_hardware_concurrency",
+            "fp_timezone",
+            "fp_language",
+            "fp_platform",
         ] {
             assert!(obj.contains_key(key), "missing field: {key}");
         }
-        // `color_depth` is intentionally omitted when not available
-        // (always, on current launcher targets) thanks to `skip_serializing_if`.
-        assert!(!obj.contains_key("color_depth"));
         Ok(())
     }
 
     #[test]
-    fn platform_string_includes_os_and_arch_separated_by_slash() -> Result<()> {
-        let platform = platform_string();
+    fn platform_includes_os_and_arch_separated_by_slash() -> Result<()> {
+        let platform = PLATFORM.as_str();
         let parts: Vec<&str> = platform.split('/').collect();
         assert_eq!(parts.len(), 2, "expected os/arch, got {platform}");
         let os = parts.first().ok_or_else(|| anyhow!("missing os part"))?;
@@ -145,11 +155,20 @@ mod tests {
     }
 
     #[test]
-    fn hardware_concurrency_returns_a_plausible_count() {
+    fn hardware_concurrency_is_either_absent_or_plausible() {
         // Guards against accidental overflow / wrap-around in the
-        // `u32::try_from` path. Real machines won't realistically expose
-        // thousands of logical cores.
-        let n = hardware_concurrency();
-        assert!(n < 4096, "implausibly high hardware concurrency: {n}");
+        // `u32::try_from` path. On hosts where the probe fails (some CI
+        // sandboxes) the value is `None` and that's fine.
+        if let Some(n) = hardware_concurrency() {
+            assert!(n < 4096, "implausibly high hardware concurrency: {n}");
+        }
+    }
+
+    #[test]
+    fn fingerprint_converts_into_property_map() -> Result<()> {
+        let map: Map<String, Value> = ClientFingerprint::current().into();
+        assert!(map.contains_key("fp_platform"));
+        assert!(map.contains_key("fp_screen_width"));
+        Ok(())
     }
 }

--- a/core/src/analytics/fingerprint.rs
+++ b/core/src/analytics/fingerprint.rs
@@ -1,0 +1,142 @@
+use serde::Serialize;
+
+// Cross-source attribution join with landing-site Segment events relies on
+// these field names and shapes matching `landing-site/src/modules/fingerprint.ts`
+// exactly. `timezone_offset_minutes` (sent by the browser) is intentionally
+// not mirrored here: `time::OffsetDateTime::now_local()` requires the
+// `local-offset` feature and returns `Err` from inside the tokio runtime
+// for soundness reasons. The IANA `timezone` field is more useful anyway —
+// the data warehouse can derive the offset from the timezone + event
+// timestamp at join time.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClientFingerprint {
+    screen_width: u32,
+    screen_height: u32,
+    device_pixel_ratio: f64,
+    color_depth: u32,
+    hardware_concurrency: u32,
+    timezone: String,
+    language: String,
+    platform: String,
+}
+
+impl ClientFingerprint {
+    pub fn collect() -> Self {
+        let display = primary_display_info();
+        Self {
+            screen_width: display.width,
+            screen_height: display.height,
+            device_pixel_ratio: display.scale_factor,
+            color_depth: display.color_depth,
+            hardware_concurrency: hardware_concurrency(),
+            timezone: timezone_name(),
+            language: locale(),
+            platform: platform_string(),
+        }
+    }
+}
+
+struct DisplaySnapshot {
+    width: u32,
+    height: u32,
+    scale_factor: f64,
+    color_depth: u32,
+}
+
+impl Default for DisplaySnapshot {
+    fn default() -> Self {
+        Self {
+            width: 0,
+            height: 0,
+            scale_factor: 1.0,
+            color_depth: 0,
+        }
+    }
+}
+
+fn primary_display_info() -> DisplaySnapshot {
+    let Ok(displays) = display_info::DisplayInfo::all() else {
+        return DisplaySnapshot::default();
+    };
+
+    let chosen = displays
+        .iter()
+        .find(|d| d.is_primary)
+        .or_else(|| displays.first());
+
+    match chosen {
+        Some(d) => DisplaySnapshot {
+            width: d.width,
+            height: d.height,
+            scale_factor: f64::from(d.scale_factor),
+            // `display-info` doesn't expose bit depth on every platform.
+            // Modern displays are 24- or 32-bit; pinning to 24 keeps the
+            // schema parity with the browser-side payload.
+            color_depth: 24,
+        },
+        None => DisplaySnapshot::default(),
+    }
+}
+
+fn hardware_concurrency() -> u32 {
+    std::thread::available_parallelism()
+        .map(|n| u32::try_from(n.get()).unwrap_or(u32::MAX))
+        .unwrap_or(0)
+}
+
+fn timezone_name() -> String {
+    iana_time_zone::get_timezone().unwrap_or_default()
+}
+
+fn locale() -> String {
+    sys_locale::get_locale().unwrap_or_default()
+}
+
+// Includes the arch so multi-arch builds (Apple Silicon vs Intel, ARM
+// Windows) are distinguishable: e.g. "macos/aarch64", "windows/x86_64".
+fn platform_string() -> String {
+    format!("{}/{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_produces_a_serializable_snapshot_with_every_field() {
+        let fp = ClientFingerprint::collect();
+        let value = serde_json::to_value(&fp).expect("serializable");
+        let obj = value.as_object().expect("object");
+
+        for key in [
+            "screen_width",
+            "screen_height",
+            "device_pixel_ratio",
+            "color_depth",
+            "hardware_concurrency",
+            "timezone",
+            "language",
+            "platform",
+        ] {
+            assert!(obj.contains_key(key), "missing field: {key}");
+        }
+    }
+
+    #[test]
+    fn platform_string_includes_os_and_arch_separated_by_slash() {
+        let platform = platform_string();
+        let parts: Vec<&str> = platform.split('/').collect();
+        assert_eq!(parts.len(), 2, "expected os/arch, got {platform}");
+        assert!(!parts[0].is_empty());
+        assert!(!parts[1].is_empty());
+    }
+
+    #[test]
+    fn hardware_concurrency_returns_a_plausible_count() {
+        // Guards against accidental overflow / wrap-around in the
+        // `u32::try_from` path. Real machines won't realistically expose
+        // thousands of logical cores.
+        let n = hardware_concurrency();
+        assert!(n < 4096, "implausibly high hardware concurrency: {n}");
+    }
+}

--- a/core/src/analytics/fingerprint.rs
+++ b/core/src/analytics/fingerprint.rs
@@ -165,10 +165,9 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_converts_into_property_map() -> Result<()> {
+    fn fingerprint_converts_into_property_map() {
         let map: Map<String, Value> = ClientFingerprint::current().into();
         assert!(map.contains_key("fp_platform"));
         assert!(map.contains_key("fp_screen_width"));
-        Ok(())
     }
 }


### PR DESCRIPTION
# feat: emit device fingerprint signals on every analytics event

## Why

We're moving the anonymous landing → download → install funnel from a per-binary embedded `anon_user_id` (which currently costs ~40 s of SSL.com signing per Windows download) to a server-side join: landing-site events carry an IP + heuristic fingerprint, the launcher carries the equivalent fingerprint, and the data warehouse stitches them together with bounded accuracy loss (~20–30 % from NAT / VPN collisions).

The matching companion PR on the landing-site side adds the same set of fields to its Segment download events (`feat/segment-fingerprint-enrichment`). This PR is the launcher half — without it, the join only has IP + timestamp to work with, which is far too lossy on shared networks.

## What changes

- `core/src/analytics/fingerprint.rs` (new) — `ClientFingerprint::collect()` reads stable OS signals and returns a `Serialize` struct: primary monitor `screen_width` / `screen_height` / `device_pixel_ratio` / `color_depth`, `hardware_concurrency`, IANA `timezone`, `language`, and `platform` (formatted as `os/arch`, e.g. `windows/x86_64`). Each individual probe falls back to a zero / empty value rather than panicking on locked-down hosts (CI, RDP without a monitor, etc.).
- `core/src/analytics.rs` — registers the new `fingerprint` module under `analytics`.
- `core/src/analytics/client.rs` — `AnalyticsClient` now collects a single `ClientFingerprint` snapshot at construction time and merges its fields into every `track()` event's `properties` map. Existing per-event properties win over the fingerprint defaults so a future event-level override stays intact.
- `core/Cargo.toml` — adds three small cross-platform crates: `display-info` (monitor info), `iana-time-zone` (IANA timezone name), `sys-locale` (OS locale). Each is well-maintained and dep-light.

## Field shape (matches `landing-site/src/modules/fingerprint.ts`)

```jsonc
{
  "screen_width": 2560,
  "screen_height": 1440,
  "device_pixel_ratio": 2.0,
  "color_depth": 24,
  "hardware_concurrency": 8,
  "timezone": "America/Argentina/Buenos_Aires",
  "language": "es-AR",
  "platform": "macos/aarch64"
}
```

## What's deliberately missing

**`timezone_offset_minutes`** — the landing-site sends this (browser's `Date.prototype.getTimezoneOffset()` makes it free) but the Rust `time` crate's `OffsetDateTime::now_local()` requires the `local-offset` feature and returns `Err` in multi-threaded processes for soundness reasons. The launcher runs the analytics client from inside the tokio runtime, so the call would essentially always fail.

The IANA `timezone` string is more useful anyway (accounts for DST and historical zone changes) and the data warehouse can derive the numeric offset from `timezone` + event timestamp at join time. Adding a frequently-zero or frequently-erroring field to every event payload would be worse than the current schema mismatch.

## Privacy & telemetry surface

Every field is already covered by the launcher's existing telemetry posture (we already emit `os`, `launcherVersion`, `sessionId`, `campaign_anon_user_id` on every event). The new fields are low-entropy on their own — only useful when combined with IP and timestamp for fingerprint matching — and contain no PII.

## Test plan

- [x] `cargo build --release --manifest-path core/Cargo.toml` passes
- [x] `cargo clippy --release --manifest-path core/Cargo.toml -- -D warnings` clean
- [x] `cargo test --release --manifest-path core/Cargo.toml fingerprint` — 3 / 3 cases passing (serializable shape, platform format, hardware-concurrency sanity)
- [ ] Manual: run a release build on macOS and on Windows, look at a recent event in Segment debugger, confirm the new fields are populated with sensible values for the host machine
- [ ] Coordinate with data team to confirm landing-site → launcher join is producing matches at the expected accuracy once both sides are in prod

## Deploy ordering

This PR can be merged and released independently. It only adds fields to existing analytics events — no behavioural change for users. **Do not deploy the gateway pass-through PR (`client-download-gateway#feat/passthrough-anon-exe-server-side-attribution`) until this launcher release is rolled out to a meaningful fraction of users**, otherwise during the rollout window we'd be losing per-binary attribution before the server-side join has launcher events with the matching features to work with.
