### PR TITLE
feat: embed git commit + PR number into builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,8 @@ jobs:
           SEGMENT_API_KEY: ${{ secrets.SEGMENT_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           LAUNCHER_ENVIRONMENT: prod
+          GIT_COMMIT: ${{ github.sha }}
+          PR_NUMBER: ${{ inputs.pr-number || 'na' }}
           ES_USERNAME: ${{ secrets.ES_USERNAME }}
           ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
           WINDOWS_CREDENTIAL_ID_SIGNER: ${{ secrets.WINDOWS_CREDENTIAL_ID_SIGNER }}
@@ -270,6 +272,8 @@ jobs:
           SEGMENT_API_KEY: ${{ secrets.SEGMENT_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           LAUNCHER_ENVIRONMENT: dev
+          GIT_COMMIT: ${{ github.sha }}
+          PR_NUMBER: ${{ inputs.pr-number || 'na' }}
         with:
           args: ${{ secrets.args }}
           projectPath: ${{ env.PROJECT_PATH }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ When a `decentraland://` link arrives while the Explorer is already running, the
 
 - Extract complex if/else branches into named functions for readability. Prefer named free functions (`fn as_rename_back_err(...)`) over closures for error mapping.
 - Public functions that take user-influenced strings for path construction should validate inputs locally (e.g. reject `/` or `\` in version strings) even if upstream code already constrains them — keeps the safety invariant self-documenting.
+- Compile-time values belong in `const` items, not `const fn` getters: `pub const BUILD_COMMIT: &str = match option_env!("GIT_COMMIT") { ... }` rather than a zero-arg `const fn build_commit()`.
+- Don't repeat the same expression/comparison twice in a function — extract it into a named local (e.g. `let is_pr_build = BUILD_PR != "na";`).
 
 ### Install edge cases
 

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -15,7 +15,7 @@ use crate::auto_auth::AutoAuth;
 use log::{error, info};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use utils::{app_version, build_commit, build_pr};
+use utils::{BUILD_COMMIT, BUILD_PR, app_version};
 
 pub struct AppState {
     pub flow: LaunchFlow,
@@ -31,8 +31,8 @@ impl AppState {
         info!(
             "Application setup start. Version: {} commit: {} pr: {}",
             app_version(),
-            build_commit(),
-            build_pr()
+            BUILD_COMMIT,
+            BUILD_PR
         );
 
         std::panic::set_hook(Box::new(|info| error!("Panic occurred: {:?}", info)));

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -15,7 +15,7 @@ use crate::auto_auth::AutoAuth;
 use log::{error, info};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use utils::app_version;
+use utils::{app_version, build_commit, build_pr};
 
 pub struct AppState {
     pub flow: LaunchFlow,
@@ -28,7 +28,12 @@ impl AppState {
     pub async fn setup() -> Result<Self> {
         logs::dispath_logs()?;
 
-        info!("Application setup start. Version: {}", app_version());
+        info!(
+            "Application setup start. Version: {} commit: {} pr: {}",
+            app_version(),
+            build_commit(),
+            build_pr()
+        );
 
         std::panic::set_hook(Box::new(|info| error!("Panic occurred: {:?}", info)));
 

--- a/core/src/monitoring.rs
+++ b/core/src/monitoring.rs
@@ -10,7 +10,7 @@ use sentry_types::Dsn;
 use crate::{
     config,
     environment::AppEnvironment,
-    utils::{build_commit, build_pr},
+    utils::{BUILD_COMMIT, BUILD_PR},
 };
 
 pub struct Monitoring {}
@@ -34,16 +34,18 @@ impl Monitoring {
                 let env = format!("{:?}", AppEnvironment::launcher_environment()).to_lowercase();
                 info!("sentry environment selected: {}", env);
 
-                let release = if build_pr() == "na" {
-                    sentry::release_name!()
-                } else {
+                let is_pr_build = BUILD_PR != "na";
+
+                let release = if is_pr_build {
                     Some(Cow::Owned(format!(
                         "{}@{}-pr.{}+{}",
                         env!("CARGO_PKG_NAME"),
                         env!("CARGO_PKG_VERSION"),
-                        build_pr(),
-                        build_commit()
+                        BUILD_PR,
+                        BUILD_COMMIT
                     )))
+                } else {
+                    sentry::release_name!()
                 };
 
                 let opts = ClientOptions {
@@ -69,9 +71,9 @@ impl Monitoring {
                         id: Some(user_id),
                         ..Default::default()
                     }));
-                    if build_pr() != "na" {
-                        scope.set_tag("git_commit", build_commit());
-                        scope.set_tag("pr_number", build_pr());
+                    if is_pr_build {
+                        scope.set_tag("git_commit", BUILD_COMMIT);
+                        scope.set_tag("pr_number", BUILD_PR);
                     }
                 });
 

--- a/core/src/monitoring.rs
+++ b/core/src/monitoring.rs
@@ -34,16 +34,23 @@ impl Monitoring {
                 let env = format!("{:?}", AppEnvironment::launcher_environment()).to_lowercase();
                 info!("sentry environment selected: {}", env);
 
-                let release = format!(
-                    "{}@{}+{}",
-                    env!("CARGO_PKG_NAME"),
-                    env!("CARGO_PKG_VERSION"),
-                    build_commit()
-                );
-                info!("sentry release: {}", release);
+                // Prod (PR_NUMBER=na) keeps `name@version` unchanged so existing
+                // Sentry release-health history and alerts continue to work.
+                // PR builds get a unique release per (pr, commit).
+                let release = if build_pr() == "na" {
+                    sentry::release_name!()
+                } else {
+                    Some(Cow::Owned(format!(
+                        "{}@{}-pr.{}+{}",
+                        env!("CARGO_PKG_NAME"),
+                        env!("CARGO_PKG_VERSION"),
+                        build_pr(),
+                        build_commit()
+                    )))
+                };
 
                 let opts = ClientOptions {
-                    release: Some(Cow::Owned(release)),
+                    release,
                     dsn: Some(dsn),
                     attach_stacktrace: true,
                     auto_session_tracking: true,
@@ -65,8 +72,10 @@ impl Monitoring {
                         id: Some(user_id),
                         ..Default::default()
                     }));
-                    scope.set_tag("git_commit", build_commit());
-                    scope.set_tag("pr_number", build_pr());
+                    if build_pr() != "na" {
+                        scope.set_tag("git_commit", build_commit());
+                        scope.set_tag("pr_number", build_pr());
+                    }
                 });
 
                 Ok(())

--- a/core/src/monitoring.rs
+++ b/core/src/monitoring.rs
@@ -34,9 +34,6 @@ impl Monitoring {
                 let env = format!("{:?}", AppEnvironment::launcher_environment()).to_lowercase();
                 info!("sentry environment selected: {}", env);
 
-                // Prod (PR_NUMBER=na) keeps `name@version` unchanged so existing
-                // Sentry release-health history and alerts continue to work.
-                // PR builds get a unique release per (pr, commit).
                 let release = if build_pr() == "na" {
                     sentry::release_name!()
                 } else {

--- a/core/src/monitoring.rs
+++ b/core/src/monitoring.rs
@@ -7,7 +7,11 @@ use log::{error, info};
 use sentry::{ClientOptions, protocol::User};
 use sentry_types::Dsn;
 
-use crate::{config, environment::AppEnvironment};
+use crate::{
+    config,
+    environment::AppEnvironment,
+    utils::{build_commit, build_pr},
+};
 
 pub struct Monitoring {}
 
@@ -30,8 +34,16 @@ impl Monitoring {
                 let env = format!("{:?}", AppEnvironment::launcher_environment()).to_lowercase();
                 info!("sentry environment selected: {}", env);
 
+                let release = format!(
+                    "{}@{}+{}",
+                    env!("CARGO_PKG_NAME"),
+                    env!("CARGO_PKG_VERSION"),
+                    build_commit()
+                );
+                info!("sentry release: {}", release);
+
                 let opts = ClientOptions {
-                    release: sentry::release_name!(),
+                    release: Some(Cow::Owned(release)),
                     dsn: Some(dsn),
                     attach_stacktrace: true,
                     auto_session_tracking: true,
@@ -53,6 +65,8 @@ impl Monitoring {
                         id: Some(user_id),
                         ..Default::default()
                     }));
+                    scope.set_tag("git_commit", build_commit());
+                    scope.set_tag("pr_number", build_pr());
                 });
 
                 Ok(())

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -43,12 +43,18 @@ pub const fn app_version() -> &'static str {
 
 #[must_use]
 pub const fn build_commit() -> &'static str {
-    option_env!("GIT_COMMIT").unwrap_or("local")
+    match option_env!("GIT_COMMIT") {
+        Some(s) => s,
+        None => "local",
+    }
 }
 
 #[must_use]
 pub const fn build_pr() -> &'static str {
-    option_env!("PR_NUMBER").unwrap_or("na")
+    match option_env!("PR_NUMBER") {
+        Some(s) => s,
+        None => "na",
+    }
 }
 
 /**

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -41,6 +41,16 @@ pub const fn app_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+#[must_use]
+pub const fn build_commit() -> &'static str {
+    option_env!("GIT_COMMIT").unwrap_or("local")
+}
+
+#[must_use]
+pub const fn build_pr() -> &'static str {
+    option_env!("PR_NUMBER").unwrap_or("na")
+}
+
 /**
  * Determines if should run the dev version of the Explorer when passing the arguments --dev or --version=dev.
  * @returns A boolean value indicating if the Explorer should run the explorer from the dev path.

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -41,21 +41,15 @@ pub const fn app_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
-#[must_use]
-pub const fn build_commit() -> &'static str {
-    match option_env!("GIT_COMMIT") {
-        Some(s) => s,
-        None => "local",
-    }
-}
+pub const BUILD_COMMIT: &str = match option_env!("GIT_COMMIT") {
+    Some(s) => s,
+    None => "local",
+};
 
-#[must_use]
-pub const fn build_pr() -> &'static str {
-    match option_env!("PR_NUMBER") {
-        Some(s) => s,
-        None => "na",
-    }
-}
+pub const BUILD_PR: &str = match option_env!("PR_NUMBER") {
+    Some(s) => s,
+    None => "na",
+};
 
 /**
  * Determines if should run the dev version of the Explorer when passing the arguments --dev or --version=dev.


### PR DESCRIPTION
## Summary

Bake `GIT_COMMIT` and `PR_NUMBER` into the launcher binary so QA can tell a PR build apart from a prod build at runtime.

- Startup log: `Application setup start. Version: 1.16.2 commit: <sha> pr: 265`
- PR builds get a unique Sentry release (`name@version-pr.<N>+<sha>`) + `git_commit` / `pr_number` tags.
- Prod build (`PR_NUMBER=na`) keeps `sentry::release_name!()` and tags exactly as before — no Sentry behavior change.
- Local `cargo build` falls back to `commit: local pr: na`.

## Test plan

- [ ] Dry-run build of this PR: `output.log` shows `commit: <sha> pr: 273`.
- [ ] Sentry event from the dry-run build has release `...-pr.273+<sha>` and the two new tags.
- [ ] Release build from `main` produces release `name@<version>`, no `git_commit` / `pr_number` tags (unchanged from today).
- [ ] Local `cargo build` startup log shows `commit: local pr: na`.