### PR TITLE
fix: demote duplicate flow error log to Sentry breadcrumb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@ When a `decentraland://` link arrives while the Explorer is already running, the
 - Every distinct IO failure point should have its own Sentry error code (e.g. E3005, E3006, E3007) rather than falling through to `E0000_GENERIC_ERROR`. Specific codes let Sentry pivot on each failure independently.
 - User-facing messages for file-system errors on Windows should advise closing the Decentraland client before retrying — the most common cause of rename/cleanup failures is the Explorer holding file locks.
 
+### Sentry logging
+
+- `SentryLogger` (core/src/logs.rs) turns every `log::error!` into its own message-grouped Sentry event. If an error is already reported via `sentry::capture_error` (which carries the per-code fingerprint), its companion `log::error!` must use `target: crate::logs::SENTRY_BREADCRUMB_ONLY_TARGET` so it becomes a breadcrumb on the captured event instead of a duplicate, unfingerprinted issue.
+- Demotion must stay opt-in at the call site. Never filter by module path or level blanket-wide — a future unpaired `log::error!` in that module would then silently stop creating Sentry issues.
+
 ### Code style (Rust)
 
 - Extract complex if/else branches into named functions for readability. Prefer named free functions (`fn as_rename_back_err(...)`) over closures for error mapping.

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -114,7 +114,11 @@ impl LaunchFlow {
             let result = self.launch_internal(channel, state.clone()).await;
 
             if let Err(e) = result {
+                // Breadcrumb-only: the error itself is captured just below
+                // with a per-code fingerprint; a plain error log would create
+                // a second, message-grouped Sentry issue per attempt.
                 log::error!(
+                    target: crate::logs::SENTRY_BREADCRUMB_ONLY_TARGET,
                     "Error during the flow. Attempt: {}, Cause {} {:#?}",
                     attempt,
                     e,

--- a/core/src/logs.rs
+++ b/core/src/logs.rs
@@ -39,12 +39,27 @@ pub fn dispath_logs() -> Result<()> {
     Ok(())
 }
 
+/// Opt-in log target for error logs that must NOT become standalone Sentry
+/// events. Use it only on `log::error!` lines that duplicate an error already
+/// reported via `sentry::capture_error` (which carries the grouping
+/// fingerprint) — the log line then rides along as a breadcrumb instead of
+/// creating a second, message-grouped issue.
+pub const SENTRY_BREADCRUMB_ONLY_TARGET: &str = "sentry_breadcrumb_only";
+
 fn new_sentry_log() -> SentryLogger<pretty_env_logger::env_logger::Logger> {
     // setup as in the guide: https://crates.io/crates/sentry-log
     let mut log_builder = pretty_env_logger::formatted_builder();
     log_builder.parse_filters("info");
     let log = log_builder.build();
-    sentry_log::SentryLogger::with_dest(log)
+    sentry_log::SentryLogger::with_dest(log).filter(breadcrumb_only_filter)
+}
+
+fn breadcrumb_only_filter(metadata: &Metadata) -> sentry_log::LogFilter {
+    if metadata.target() == SENTRY_BREADCRUMB_ONLY_TARGET {
+        sentry_log::LogFilter::Breadcrumb
+    } else {
+        sentry_log::default_filter(metadata)
+    }
 }
 
 struct CombinedLog {


### PR DESCRIPTION
## Problem

Every flow error reaches Sentry **twice**:

1. `sentry::capture_error` — fingerprinted by error code (shipped in #267), groups into one issue per code ✅
2. The `log::error!` line right before it — `sentry-log` converts error-level logs into standalone events with **no fingerprint**, grouped by message text ❌

The second copy fragments into separate issues per attempt number ("Error during the flow. Attempt: 1/2/3, Cause …"), which is why the issue list still looks ungrouped after #267. In release 1.17.4 data, these duplicates account for roughly half of all flow-error event volume.

## Fix

- New opt-in log target `SENTRY_BREADCRUMB_ONLY_TARGET` in `logs.rs`: error logs tagged with it become **breadcrumbs** (attached to the captured event) instead of standalone events. All other logs keep stock `sentry_log::default_filter` behavior.
- The one duplicate log line in `flow.rs` opts in via `target:`.
- Convention documented in `CLAUDE.md`: demotion must stay explicit at the call site — never blanket-filter by module/level, so a future unpaired `log::error!` still creates its own issue.

## Notes

- Nothing is lost: the line still goes to the local log file at error level, and still reaches Sentry as a breadcrumb on the fingerprinted event (including the `{:#?}` debug dump the fingerprint deliberately excludes).
- Local log file will show target `sentry_breadcrumb_only` for that line instead of the module path.
- Issue-list cleanup is only visible once a release with this ships and old versions drain; legacy fragmented issues should be bulk-resolved then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)