### PR TITLE
fix: improve deeplink passthrough handling and bridge cleanup

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -83,7 +83,11 @@ impl AppState {
             running_instances.clone(),
         )));
 
-        let flow = LaunchFlow::new(&installs_hub, analytics.clone(), &running_instances);
+        let flow = LaunchFlow::new(
+            installs_hub,
+            analytics.clone(),
+            running_instances,
+        );
         let flow_state = LaunchFlowState::default();
         let app_state = Self {
             flow,

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -83,7 +83,7 @@ impl AppState {
             running_instances.clone(),
         )));
 
-        let flow = LaunchFlow::new(installs_hub, analytics.clone(), running_instances);
+        let flow = LaunchFlow::new(&installs_hub, analytics.clone(), &running_instances);
         let flow_state = LaunchFlowState::default();
         let app_state = Self {
             flow,

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -112,7 +112,20 @@ pub fn should_use_deeplink_bridge(
     let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
     let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || args.bridge_only;
 
-    !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
+    let use_bridge = !open_new_instance && (any_is_running || bridge_only) && !is_local_scene;
+
+    log::info!(
+        "[deeplink-debug] should_use_deeplink_bridge -> {use_bridge} | deeplink={:?} | \
+         open_new_instance={open_new_instance} (multi_instance_deeplink={}, arg_open_new={}) | \
+         bridge_only={bridge_only} | is_local_scene={is_local_scene} | any_is_running={any_is_running} \
+         => {}",
+        deeplink.original(),
+        deeplink.has_true_value(ARG_MULTI_INSTANCE),
+        args.open_new_client_instance,
+        if use_bridge { "BRIDGE to running instance" } else { "LAUNCH new instance" },
+    );
+
+    use_bridge
 }
 
 pub async fn should_use_deeplink_bridge_for(

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use std::time::Duration;
 use serde::Serialize;
 use tokio::fs::remove_file;
-use tokio::time::error::Elapsed;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
@@ -115,12 +114,9 @@ pub fn should_use_deeplink_bridge(
     !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
 }
 
-pub async fn should_use_deeplink_bridge_for(
-    deeplink: &DeepLink,
-    any_is_running: bool,
-) -> anyhow::Result<bool> {
+pub fn should_use_deeplink_bridge_for(deeplink: &DeepLink, any_is_running: bool) -> bool {
     let args = AppEnvironment::cmd_args();
-    Ok(should_use_deeplink_bridge(deeplink, &args, any_is_running))
+    should_use_deeplink_bridge(deeplink, &args, any_is_running)
 }
 
 pub async fn execute_passthrough<T: EventChannel>(
@@ -128,7 +124,6 @@ pub async fn execute_passthrough<T: EventChannel>(
     deeplink: &DeepLink,
 ) -> StepResult {
     const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
-    type OpenResult = std::result::Result<PlaceDeeplinkResult, Elapsed>;
 
     channel.send(Status::State {
         step: Step::DeeplinkOpening,
@@ -144,33 +139,40 @@ pub async fn execute_passthrough<T: EventChannel>(
 
     let token = CancellationToken::new();
 
-    match tokio::time::timeout(
-        OPEN_DEEPLINK_TIMEOUT,
-        place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
-    )
-    .await
-    {
-        OpenResult::Ok(result) => match result {
-            PlaceDeeplinkResult::Ok(outcome) => {
-                // Once the deeplink is placed and consumed, activate the packaged Explorer window,
-                // but skip it in bridge-only mode (the consumer owns focus).
-                if outcome == DeeplinkConsumeOutcome::Consumed && bring_to_front {
-                    #[cfg(target_os = "macos")]
-                    try_bring_explorer_to_front();
-                }
-                StepResult::Ok(())
-            }
-            PlaceDeeplinkResult::Err(error) => match error {
-                PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
-                    StepResult::Err(error.into())
-                }
-                PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
-            },
-        },
-        OpenResult::Err(_) => {
+    // Pin the wait future locally so it is NOT dropped when the timer fires. That keeps its
+    // `select!` loop alive, so cancelling the token drives its own cancel branch (and cleanup).
+    let mut wait = std::pin::pin!(place_deeplink_and_wait_until_consumed(
+        deeplink.clone(),
+        token.child_token(),
+    ));
+
+    let result = tokio::select! {
+        r = &mut wait => r,
+        () = sleep(OPEN_DEEPLINK_TIMEOUT) => {
+            // Future is still alive: cancelling wakes its `token.cancelled()` arm, and awaiting it
+            // to completion lets that arm remove the bridge file before we report the timeout.
             token.cancel();
-            StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
+            let _ = (&mut wait).await;
+            return StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT);
         }
+    };
+
+    match result {
+        PlaceDeeplinkResult::Ok(outcome) => {
+            // Once the deeplink is placed and consumed, activate the packaged Explorer window,
+            // but skip it in bridge-only mode (the consumer owns focus).
+            if outcome == DeeplinkConsumeOutcome::Consumed && bring_to_front {
+                #[cfg(target_os = "macos")]
+                try_bring_explorer_to_front();
+            }
+            StepResult::Ok(())
+        }
+        PlaceDeeplinkResult::Err(error) => match error {
+            PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
+                StepResult::Err(error.into())
+            }
+            PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
+        },
     }
 }
 

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -190,17 +190,14 @@ pub async fn place_deeplink_and_wait_until_consumed(
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
     use crate::environment::Args;
     use crate::protocols::DeepLink;
-    use std::collections::HashMap;
 
-    fn deeplink(flags: &[(&str, &str)]) -> DeepLink {
-        let mut map: HashMap<String, String> = HashMap::new();
-        for (key, value) in flags {
-            map.insert((*key).to_owned(), (*value).to_owned());
-        }
-        DeepLink::from_args(map)
+    fn deeplink(value: &str) -> DeepLink {
+        DeepLink::from_string(value.to_string()).unwrap()
     }
 
     fn args(argv: &[&str]) -> Args {
@@ -210,7 +207,7 @@ mod tests {
     #[test]
     fn uses_bridge_when_running_and_no_special_flags() {
         assert!(should_use_deeplink_bridge(
-            &deeplink(&[]),
+            &deeplink("decentraland://"),
             &args(&["app"]),
             true
         ));
@@ -219,7 +216,7 @@ mod tests {
     #[test]
     fn no_bridge_when_no_instance_running() {
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&[]),
+            &deeplink("decentraland://"),
             &args(&["app"]),
             false
         ));
@@ -228,12 +225,12 @@ mod tests {
     #[test]
     fn no_bridge_when_new_instance_requested_via_deeplink() {
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&[(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE, "true")]),
+            &deeplink(&format!("decentraland://{}=true", ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)),
             &args(&["app"]),
             true
         ));
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&[(ARG_MULTI_INSTANCE, "true")]),
+            &deeplink(&format!("decentraland://{}=true", ARG_MULTI_INSTANCE)),
             &args(&["app"]),
             true
         ));
@@ -242,7 +239,7 @@ mod tests {
     #[test]
     fn no_bridge_when_new_instance_requested_via_args() {
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&[]),
+            &deeplink("decentraland://"),
             &args(&["app", "--open-deeplink-in-new-instance"]),
             true
         ));
@@ -251,12 +248,12 @@ mod tests {
     #[test]
     fn no_bridge_for_local_scene() {
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&[(ARG_LOCAL_SCENE, "true")]),
+            &deeplink(&format!("decentraland://{}=true", ARG_LOCAL_SCENE)),
             &args(&["app"]),
             true
         ));
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&[]),
+            &deeplink("decentraland://"),
             &args(&["app", "--local-scene"]),
             true
         ));

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -190,14 +190,12 @@ pub async fn place_deeplink_and_wait_until_consumed(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
-
     use super::*;
     use crate::environment::Args;
-    use crate::protocols::DeepLink;
+    use crate::protocols::{DeepLink, DeepLinkCreateError};
 
-    fn deeplink(value: &str) -> DeepLink {
-        DeepLink::from_string(value.to_string()).unwrap()
+    fn deeplink(value: &str) -> Result<DeepLink, DeepLinkCreateError> {
+        DeepLink::from_string(value.to_string())
     }
 
     fn args(argv: &[&str]) -> Args {
@@ -205,57 +203,62 @@ mod tests {
     }
 
     #[test]
-    fn uses_bridge_when_running_and_no_special_flags() {
+    fn uses_bridge_when_running_and_no_special_flags() -> Result<(), DeepLinkCreateError> {
         assert!(should_use_deeplink_bridge(
-            &deeplink("decentraland://"),
+            &deeplink("decentraland://")?,
             &args(&["app"]),
             true
         ));
+        Ok(())
     }
 
     #[test]
-    fn no_bridge_when_no_instance_running() {
+    fn no_bridge_when_no_instance_running() -> Result<(), DeepLinkCreateError> {
         assert!(!should_use_deeplink_bridge(
-            &deeplink("decentraland://"),
+            &deeplink("decentraland://")?,
             &args(&["app"]),
             false
         ));
+        Ok(())
     }
 
     #[test]
-    fn no_bridge_when_new_instance_requested_via_deeplink() {
+    fn no_bridge_when_new_instance_requested_via_deeplink() -> Result<(), DeepLinkCreateError> {
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&format!("decentraland://{}=true", ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)),
+            &deeplink(&format!("decentraland://{}=true", ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE))?,
             &args(&["app"]),
             true
         ));
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&format!("decentraland://{}=true", ARG_MULTI_INSTANCE)),
+            &deeplink(&format!("decentraland://{}=true", ARG_MULTI_INSTANCE))?,
             &args(&["app"]),
             true
         ));
+        Ok(())
     }
 
     #[test]
-    fn no_bridge_when_new_instance_requested_via_args() {
+    fn no_bridge_when_new_instance_requested_via_args() -> Result<(), DeepLinkCreateError> {
         assert!(!should_use_deeplink_bridge(
-            &deeplink("decentraland://"),
+            &deeplink("decentraland://")?,
             &args(&["app", "--open-deeplink-in-new-instance"]),
             true
         ));
+        Ok(())
     }
 
     #[test]
-    fn no_bridge_for_local_scene() {
+    fn no_bridge_for_local_scene() -> Result<(), DeepLinkCreateError> {
         assert!(!should_use_deeplink_bridge(
-            &deeplink(&format!("decentraland://{}=true", ARG_LOCAL_SCENE)),
+            &deeplink(&format!("decentraland://{}=true", ARG_LOCAL_SCENE))?,
             &args(&["app"]),
             true
         ));
         assert!(!should_use_deeplink_bridge(
-            &deeplink("decentraland://"),
+            &deeplink("decentraland://")?,
             &args(&["app", "--local-scene"]),
             true
         ));
+        Ok(())
     }
 }

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -62,6 +62,9 @@ pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
 /// Keep it in mind using this function.
 #[cfg(target_os = "macos")]
 fn try_bring_explorer_to_front() {
+    log::info!(
+        "try_bring_explorer_to_front: invoking `open <app>` — if no Explorer is currently running this will LAUNCH a new instance"
+    );
     let app_path = match crate::installs::get_explorer_launch_path(None) {
         Ok(p) => p,
         Err(e) => {
@@ -103,7 +106,24 @@ pub fn should_use_deeplink_bridge(
     let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
     let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || args.bridge_only;
 
-    !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
+    let use_bridge = !open_new_instance && (any_is_running || bridge_only) && !is_local_scene;
+
+    log::info!(
+        "should_use_deeplink_bridge -> {use_bridge} | deeplink={:?} | open_new_instance={open_new_instance} \
+         (deeplink_new_instance={}, deeplink_multi_instance={}, arg_open_new={}) | \
+         is_local_scene={is_local_scene} (deeplink={}, arg={}) | \
+         bridge_only={bridge_only} (deeplink={}, arg={}) | any_is_running={any_is_running}",
+        deeplink.original(),
+        deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE),
+        deeplink.has_true_value(ARG_MULTI_INSTANCE),
+        args.open_new_client_instance,
+        deeplink.has_true_value(ARG_LOCAL_SCENE),
+        args.local_scene,
+        deeplink.has_true_value(ARG_BRIDGE_ONLY),
+        args.bridge_only,
+    );
+
+    use_bridge
 }
 
 pub async fn should_use_deeplink_bridge_for(
@@ -143,6 +163,10 @@ pub async fn execute_passthrough<T: EventChannel>(
             },
         },
         OpenResult::Err(_) => {
+            log::warn!(
+                "execute_passthrough: deeplink bridge timed out after {OPEN_DEEPLINK_TIMEOUT:?} \
+                 (no Explorer consumed the bridge file); returning E3001 and NOT launching a new instance"
+            );
             token.cancel();
             StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
         }
@@ -155,6 +179,16 @@ pub async fn place_deeplink_and_wait_until_consumed(
 ) -> PlaceDeeplinkResult {
     let path = deeplink_bridge_path();
 
+    // If a stale bridge file is left over from a previous run, its later disappearance could be
+    // misread as "consumed by a running Explorer". Log whether one already exists before we write.
+    if path.exists() {
+        log::warn!(
+            "place_deeplink_and_wait_until_consumed: a bridge file already exists at {} before writing \
+             (possible stale file from a previous run)",
+            path.display()
+        );
+    }
+
     // Write deeplink to file
     {
         let dto = DeepLinkBridgeDTO {
@@ -163,17 +197,26 @@ pub async fn place_deeplink_and_wait_until_consumed(
         let json = serde_json::to_string(&dto)?;
         File::create(&path)?.write_all(json.as_bytes())?;
     }
+    log::info!(
+        "place_deeplink_and_wait_until_consumed: wrote bridge file at {}, waiting for an Explorer to consume it",
+        path.display()
+    );
 
     // Wait until file is deleted or operation is cancelled
     loop {
         tokio::select! {
             () = token.cancelled() => {
+                log::info!("place_deeplink_and_wait_until_consumed: cancelled before consumption, cleaning up bridge file");
                 // Clean up on cancel
                 let _ = remove_file(&path).await;
                 break;
             },
             () = sleep(Duration::from_millis(50)) => {
                 if !path.exists() {
+                    log::info!(
+                        "place_deeplink_and_wait_until_consumed: bridge file was removed (treated as consumed); \
+                         calling try_bring_explorer_to_front (WARNING: this may open a NEW instance if none is running)"
+                    );
 
                     // Bring the Explorer window to the front only in case if the deeplink was consumed
                     #[cfg(target_os = "macos")]

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -112,20 +112,7 @@ pub fn should_use_deeplink_bridge(
     let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
     let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || args.bridge_only;
 
-    let use_bridge = !open_new_instance && (any_is_running || bridge_only) && !is_local_scene;
-
-    log::info!(
-        "[deeplink-debug] should_use_deeplink_bridge -> {use_bridge} | deeplink={:?} | \
-         open_new_instance={open_new_instance} (multi_instance_deeplink={}, arg_open_new={}) | \
-         bridge_only={bridge_only} | is_local_scene={is_local_scene} | any_is_running={any_is_running} \
-         => {}",
-        deeplink.original(),
-        deeplink.has_true_value(ARG_MULTI_INSTANCE),
-        args.open_new_client_instance,
-        if use_bridge { "BRIDGE to running instance" } else { "LAUNCH new instance" },
-    );
-
-    use_bridge
+    !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
 }
 
 pub async fn should_use_deeplink_bridge_for(

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -55,7 +55,16 @@ impl From<std::io::Error> for PlaceDeeplinkError {
     }
 }
 
-pub type PlaceDeeplinkResult = Result<(), PlaceDeeplinkError>;
+/// How `place_deeplink_and_wait_until_consumed` finished waiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeeplinkConsumeOutcome {
+    /// The bridge file disappeared, i.e. some process picked up the deeplink.
+    Consumed,
+    /// Waiting was cancelled before the file was consumed.
+    Cancelled,
+}
+
+pub type PlaceDeeplinkResult = Result<DeeplinkConsumeOutcome, PlaceDeeplinkError>;
 
 /// Uses `open <path-to-.app>` so Launch Services activates the already-running instance by bundle id.
 /// Since the function internally uses "open" command and if instance is not running then it may accidentally open new instance of the app.
@@ -157,12 +166,20 @@ pub async fn execute_passthrough<T: EventChannel>(
 
     match tokio::time::timeout(
         OPEN_DEEPLINK_TIMEOUT,
-        place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token(), bring_to_front),
+        place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
     )
     .await
     {
         OpenResult::Ok(result) => match result {
-            PlaceDeeplinkResult::Ok(()) => StepResult::Ok(()),
+            PlaceDeeplinkResult::Ok(outcome) => {
+                // Once the deeplink is placed and consumed, activate the packaged Explorer window,
+                // but skip it in bridge-only mode (the consumer owns focus).
+                if outcome == DeeplinkConsumeOutcome::Consumed && bring_to_front {
+                    #[cfg(target_os = "macos")]
+                    try_bring_explorer_to_front();
+                }
+                StepResult::Ok(())
+            }
             PlaceDeeplinkResult::Err(error) => match error {
                 PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
                     StepResult::Err(error.into())
@@ -184,7 +201,6 @@ pub async fn execute_passthrough<T: EventChannel>(
 pub async fn place_deeplink_and_wait_until_consumed(
     deeplink: DeepLink,
     token: CancellationToken,
-    bring_to_front: bool,
 ) -> PlaceDeeplinkResult {
     let path = deeplink_bridge_path();
 
@@ -207,7 +223,7 @@ pub async fn place_deeplink_and_wait_until_consumed(
         File::create(&path)?.write_all(json.as_bytes())?;
     }
     log::info!(
-        "place_deeplink_and_wait_until_consumed: wrote bridge file at {}, waiting for an Explorer to consume it",
+        "place_deeplink_and_wait_until_consumed: wrote bridge file at {}, waiting for it to be consumed",
         path.display()
     );
 
@@ -218,34 +234,16 @@ pub async fn place_deeplink_and_wait_until_consumed(
                 log::info!("place_deeplink_and_wait_until_consumed: cancelled before consumption, cleaning up bridge file");
                 // Clean up on cancel
                 let _ = remove_file(&path).await;
-                break;
+                return Ok(DeeplinkConsumeOutcome::Cancelled);
             },
             () = sleep(Duration::from_millis(50)) => {
                 if !path.exists() {
-                    if !bring_to_front {
-                        log::info!(
-                            "place_deeplink_and_wait_until_consumed: bridge file consumed in bridge-only mode; \
-                             NOT activating the packaged Explorer (the consumer owns focus)"
-                        );
-                        break;
-                    }
-
-                    log::info!(
-                        "place_deeplink_and_wait_until_consumed: bridge file was removed (treated as consumed); \
-                         calling try_bring_explorer_to_front"
-                    );
-
-                    // Bring the Explorer window to the front only in case if the deeplink was consumed
-                    #[cfg(target_os = "macos")]
-                    try_bring_explorer_to_front();
-
-                    break;
+                    log::info!("place_deeplink_and_wait_until_consumed: bridge file was removed (consumed)");
+                    return Ok(DeeplinkConsumeOutcome::Consumed);
                 }
             }
         }
     }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -28,7 +28,6 @@ struct DeepLinkBridgeDTO {
 pub enum PlaceDeeplinkError {
     SerializeError,
     IOError,
-    Cancelled,
 }
 
 impl Display for PlaceDeeplinkError {
@@ -37,7 +36,6 @@ impl Display for PlaceDeeplinkError {
         match self {
             SerializeError => write!(f, "Failed to serialize deeplink data."),
             IOError => write!(f, "Failed to write deeplink to file."),
-            Cancelled => write!(f, "Operation was cancelled."),
         }
     }
 }
@@ -167,12 +165,7 @@ pub async fn execute_passthrough<T: EventChannel>(
             }
             StepResult::Ok(())
         }
-        PlaceDeeplinkResult::Err(error) => match error {
-            PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
-                StepResult::Err(error.into())
-            }
-            PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
-        },
+        PlaceDeeplinkResult::Err(error) => StepResult::Err(error.into()),
     }
 }
 

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -71,9 +71,6 @@ pub type PlaceDeeplinkResult = Result<DeeplinkConsumeOutcome, PlaceDeeplinkError
 /// Keep it in mind using this function.
 #[cfg(target_os = "macos")]
 fn try_bring_explorer_to_front() {
-    log::info!(
-        "try_bring_explorer_to_front: invoking `open <app>` — if no Explorer is currently running this will LAUNCH a new instance"
-    );
     let app_path = match crate::installs::get_explorer_launch_path(None) {
         Ok(p) => p,
         Err(e) => {
@@ -115,24 +112,7 @@ pub fn should_use_deeplink_bridge(
     let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
     let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || args.bridge_only;
 
-    let use_bridge = !open_new_instance && (any_is_running || bridge_only) && !is_local_scene;
-
-    log::info!(
-        "should_use_deeplink_bridge -> {use_bridge} | deeplink={:?} | open_new_instance={open_new_instance} \
-         (deeplink_new_instance={}, deeplink_multi_instance={}, arg_open_new={}) | \
-         is_local_scene={is_local_scene} (deeplink={}, arg={}) | \
-         bridge_only={bridge_only} (deeplink={}, arg={}) | any_is_running={any_is_running}",
-        deeplink.original(),
-        deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE),
-        deeplink.has_true_value(ARG_MULTI_INSTANCE),
-        args.open_new_client_instance,
-        deeplink.has_true_value(ARG_LOCAL_SCENE),
-        args.local_scene,
-        deeplink.has_true_value(ARG_BRIDGE_ONLY),
-        args.bridge_only,
-    );
-
-    use_bridge
+    !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
 }
 
 pub async fn should_use_deeplink_bridge_for(
@@ -188,10 +168,6 @@ pub async fn execute_passthrough<T: EventChannel>(
             },
         },
         OpenResult::Err(_) => {
-            log::warn!(
-                "execute_passthrough: deeplink bridge timed out after {OPEN_DEEPLINK_TIMEOUT:?} \
-                 (no Explorer consumed the bridge file); returning E3001 and NOT launching a new instance"
-            );
             token.cancel();
             StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
         }
@@ -204,16 +180,6 @@ pub async fn place_deeplink_and_wait_until_consumed(
 ) -> PlaceDeeplinkResult {
     let path = deeplink_bridge_path();
 
-    // If a stale bridge file is left over from a previous run, its later disappearance could be
-    // misread as "consumed by a running Explorer". Log whether one already exists before we write.
-    if path.exists() {
-        log::warn!(
-            "place_deeplink_and_wait_until_consumed: a bridge file already exists at {} before writing \
-             (possible stale file from a previous run)",
-            path.display()
-        );
-    }
-
     // Write deeplink to file
     {
         let dto = DeepLinkBridgeDTO {
@@ -222,23 +188,17 @@ pub async fn place_deeplink_and_wait_until_consumed(
         let json = serde_json::to_string(&dto)?;
         File::create(&path)?.write_all(json.as_bytes())?;
     }
-    log::info!(
-        "place_deeplink_and_wait_until_consumed: wrote bridge file at {}, waiting for it to be consumed",
-        path.display()
-    );
 
     // Wait until file is deleted or operation is cancelled
     loop {
         tokio::select! {
             () = token.cancelled() => {
-                log::info!("place_deeplink_and_wait_until_consumed: cancelled before consumption, cleaning up bridge file");
                 // Clean up on cancel
                 let _ = remove_file(&path).await;
                 return Ok(DeeplinkConsumeOutcome::Cancelled);
             },
             () = sleep(Duration::from_millis(50)) => {
                 if !path.exists() {
-                    log::info!("place_deeplink_and_wait_until_consumed: bridge file was removed (consumed)");
                     return Ok(DeeplinkConsumeOutcome::Consumed);
                 }
             }

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -145,11 +145,19 @@ pub async fn execute_passthrough<T: EventChannel>(
         step: Step::DeeplinkOpening,
     })?;
 
+    // In bridge-only mode the deeplink may be consumed by a process the launcher does not manage
+    // (e.g. an Explorer launched from the Unity editor). We must not activate the packaged app once
+    // the file is consumed, because `open <app>` would launch a spurious new instance when the
+    // packaged app is not the consumer. Bringing the window to front is only appropriate for the
+    // regular passthrough case, where the running instance is one the launcher itself started.
+    let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || AppEnvironment::cmd_args().bridge_only;
+    let bring_to_front = !bridge_only;
+
     let token = CancellationToken::new();
 
     match tokio::time::timeout(
         OPEN_DEEPLINK_TIMEOUT,
-        place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
+        place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token(), bring_to_front),
     )
     .await
     {
@@ -176,6 +184,7 @@ pub async fn execute_passthrough<T: EventChannel>(
 pub async fn place_deeplink_and_wait_until_consumed(
     deeplink: DeepLink,
     token: CancellationToken,
+    bring_to_front: bool,
 ) -> PlaceDeeplinkResult {
     let path = deeplink_bridge_path();
 
@@ -213,9 +222,17 @@ pub async fn place_deeplink_and_wait_until_consumed(
             },
             () = sleep(Duration::from_millis(50)) => {
                 if !path.exists() {
+                    if !bring_to_front {
+                        log::info!(
+                            "place_deeplink_and_wait_until_consumed: bridge file consumed in bridge-only mode; \
+                             NOT activating the packaged Explorer (the consumer owns focus)"
+                        );
+                        break;
+                    }
+
                     log::info!(
                         "place_deeplink_and_wait_until_consumed: bridge file was removed (treated as consumed); \
-                         calling try_bring_explorer_to_front (WARNING: this may open a NEW instance if none is running)"
+                         calling try_bring_explorer_to_front"
                     );
 
                     // Bring the Explorer window to the front only in case if the deeplink was consumed

--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -2,13 +2,23 @@ use std::fmt::{Display, Formatter};
 use std::fs::File;
 use std::io::Write;
 use std::time::Duration;
+use serde::Serialize;
 use tokio::fs::remove_file;
+use tokio::time::error::Elapsed;
 use tokio::time::sleep;
-
 use tokio_util::sync::CancellationToken;
 
-use crate::{installs::deeplink_bridge_path, protocols::DeepLink};
-use serde::Serialize;
+use crate::{
+    channel::EventChannel,
+    environment::{
+        AppEnvironment, Args, ARG_BRIDGE_ONLY, ARG_LOCAL_SCENE, ARG_MULTI_INSTANCE,
+        ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE,
+    },
+    errors::{StepError, StepResult},
+    installs::deeplink_bridge_path,
+    protocols::DeepLink,
+    types::{Status, Step},
+};
 
 #[derive(Serialize)]
 struct DeepLinkBridgeDTO {
@@ -82,6 +92,63 @@ fn try_bring_explorer_to_front() {
     }
 }
 
+pub fn should_use_deeplink_bridge(
+    deeplink: &DeepLink,
+    args: &Args,
+    any_is_running: bool,
+) -> bool {
+    let open_new_instance = deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)
+        || deeplink.has_true_value(ARG_MULTI_INSTANCE)
+        || args.open_new_client_instance;
+    let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
+    let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || args.bridge_only;
+
+    !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
+}
+
+pub async fn should_use_deeplink_bridge_for(
+    deeplink: &DeepLink,
+    any_is_running: bool,
+) -> anyhow::Result<bool> {
+    let args = AppEnvironment::cmd_args();
+    Ok(should_use_deeplink_bridge(deeplink, &args, any_is_running))
+}
+
+pub async fn execute_passthrough<T: EventChannel>(
+    channel: &T,
+    deeplink: &DeepLink,
+) -> StepResult {
+    const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
+    type OpenResult = std::result::Result<PlaceDeeplinkResult, Elapsed>;
+
+    channel.send(Status::State {
+        step: Step::DeeplinkOpening,
+    })?;
+
+    let token = CancellationToken::new();
+
+    match tokio::time::timeout(
+        OPEN_DEEPLINK_TIMEOUT,
+        place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
+    )
+    .await
+    {
+        OpenResult::Ok(result) => match result {
+            PlaceDeeplinkResult::Ok(()) => StepResult::Ok(()),
+            PlaceDeeplinkResult::Err(error) => match error {
+                PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
+                    StepResult::Err(error.into())
+                }
+                PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
+            },
+        },
+        OpenResult::Err(_) => {
+            token.cancel();
+            StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
+        }
+    }
+}
+
 pub async fn place_deeplink_and_wait_until_consumed(
     deeplink: DeepLink,
     token: CancellationToken,
@@ -119,4 +186,79 @@ pub async fn place_deeplink_and_wait_until_consumed(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::environment::Args;
+    use crate::protocols::DeepLink;
+    use std::collections::HashMap;
+
+    fn deeplink(flags: &[(&str, &str)]) -> DeepLink {
+        let mut map: HashMap<String, String> = HashMap::new();
+        for (key, value) in flags {
+            map.insert((*key).to_owned(), (*value).to_owned());
+        }
+        DeepLink::from_args(map)
+    }
+
+    fn args(argv: &[&str]) -> Args {
+        Args::parse(argv.iter().map(|s| (*s).to_owned()))
+    }
+
+    #[test]
+    fn uses_bridge_when_running_and_no_special_flags() {
+        assert!(should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app"]),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_bridge_when_no_instance_running() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app"]),
+            false
+        ));
+    }
+
+    #[test]
+    fn no_bridge_when_new_instance_requested_via_deeplink() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE, "true")]),
+            &args(&["app"]),
+            true
+        ));
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[(ARG_MULTI_INSTANCE, "true")]),
+            &args(&["app"]),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_bridge_when_new_instance_requested_via_args() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app", "--open-deeplink-in-new-instance"]),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_bridge_for_local_scene() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[(ARG_LOCAL_SCENE, "true")]),
+            &args(&["app"]),
+            true
+        ));
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app", "--local-scene"]),
+            true
+        ));
+    }
 }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -22,6 +22,7 @@ pub const ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE: &str = "open-deeplink-in-new-instan
 // Alias of ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE: either flag enables the same behavior.
 pub const ARG_MULTI_INSTANCE: &str = "multi-instance";
 pub const ARG_LOCAL_SCENE: &str = "local-scene";
+pub const ARG_BRIDGE_ONLY: &str = "bridge-only";
 
 #[derive(Debug)]
 pub enum LauncherEnvironment {
@@ -47,6 +48,7 @@ pub struct Args {
 
     // used by the client
     pub local_scene: bool,
+    pub bridge_only: bool,
 }
 
 impl Args {
@@ -69,6 +71,7 @@ impl Args {
                 .clone()
                 .or_else(|| other.use_latest_json_url.clone()),
             local_scene: self.local_scene || other.local_scene,
+            bridge_only: self.bridge_only || other.bridge_only,
         }
     }
 
@@ -90,6 +93,7 @@ impl Args {
             use_updater_url: Self::value_by_flag(ARG_USE_UPDATER_URL, &vector),
             use_latest_json_url: Self::value_by_flag(ARG_USE_LATEST_JSON_URL, &vector),
             local_scene: Self::has_flag(ARG_LOCAL_SCENE, &vector),
+            bridge_only: Self::has_flag(ARG_BRIDGE_ONLY, &vector),
         }
     }
 
@@ -255,6 +259,7 @@ mod tests {
             use_updater_url: Some("https://one.com".into()),
             use_latest_json_url: None,
             local_scene: false,
+            bridge_only: false,
         };
 
         let b = Args {
@@ -266,6 +271,7 @@ mod tests {
             use_updater_url: Some("https://two.com".into()),
             use_latest_json_url: Some("https://one.com".into()),
             local_scene: false,
+            bridge_only: false,
         };
 
         let merged = a.merge_with(&b);

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -24,7 +24,7 @@ pub const ARG_MULTI_INSTANCE: &str = "multi-instance";
 pub const ARG_LOCAL_SCENE: &str = "local-scene";
 /// When present, run in bridge-only mode (no client UI).
 /// Used for deeplink/file-bridge integrations and headless operations.
-pub const ARG_BRIDGE_ONLY: &str = "bridge-only";
+pub const ARG_BRIDGE_ONLY: &str = "bridgeOnly";
 
 #[derive(Debug)]
 pub enum LauncherEnvironment {

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -22,6 +22,8 @@ pub const ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE: &str = "open-deeplink-in-new-instan
 // Alias of ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE: either flag enables the same behavior.
 pub const ARG_MULTI_INSTANCE: &str = "multi-instance";
 pub const ARG_LOCAL_SCENE: &str = "local-scene";
+/// When present, run in bridge-only mode (no client UI).
+/// Used for deeplink/file-bridge integrations and headless operations.
 pub const ARG_BRIDGE_ONLY: &str = "bridge-only";
 
 #[derive(Debug)]

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -82,12 +82,12 @@ pub struct LaunchFlow {
 
 impl LaunchFlow {
     pub fn new(
-        installs_hub: &Arc<Mutex<InstallsHub>>,
+        installs_hub: Arc<Mutex<InstallsHub>>,
         analytics: Arc<Mutex<Analytics>>,
-        running_instances: &Arc<Mutex<RunningInstances>>,
+        running_instances: Arc<Mutex<RunningInstances>>,
     ) -> Self {
         let app_launch_step = AppLaunchStep {
-            installs_hub: installs_hub.clone(),
+            installs_hub,
             running_instances: running_instances.clone(),
         };
 
@@ -101,7 +101,7 @@ impl LaunchFlow {
                 running_instances: running_instances.clone(),
             },
             deeplink_passthrough_step: DeeplinkPassthroughStep {
-                app_launch_step: app_launch_step.clone(),
+                running_instances,
             },
             app_launch_step,
             analytics,
@@ -113,7 +113,11 @@ impl LaunchFlow {
             return false;
         };
 
-        match self.app_launch_step.should_use_deeplink_bridge_for(&deeplink).await {
+        match self
+            .deeplink_passthrough_step
+            .should_use_deeplink_bridge_for(&deeplink)
+            .await
+        {
             std::result::Result::Ok(should_use_bridge) => should_use_bridge,
             Err(error) => {
                 log::warn!("Cannot determine deeplink passthrough state: {error}");
@@ -481,7 +485,56 @@ struct AppLaunchStep {
 }
 
 struct DeeplinkPassthroughStep {
-    app_launch_step: AppLaunchStep,
+    running_instances: Arc<Mutex<RunningInstances>>,
+}
+
+impl DeeplinkPassthroughStep {
+    async fn is_any_instance_running(&self) -> anyhow::Result<bool> {
+        let guard = self.running_instances.lock().await;
+        guard.any_is_running()
+    }
+
+    async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
+        let args = AppEnvironment::cmd_args();
+        let any_is_running = self.is_any_instance_running().await?;
+        Ok(should_use_deeplink_bridge(deeplink, &args, any_is_running))
+    }
+
+    async fn execute_passthrough_internal<T: EventChannel>(
+        &self,
+        channel: &T,
+        deeplink: &DeepLink,
+    ) -> StepResult {
+        const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
+        type OpenResult = std::result::Result<PlaceDeeplinkResult, Elapsed>;
+
+        channel.send(Status::State {
+            step: Step::DeeplinkOpening,
+        })?;
+
+        let token = CancellationToken::new();
+
+        match tokio::time::timeout(
+            OPEN_DEEPLINK_TIMEOUT,
+            place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
+        )
+        .await
+        {
+            OpenResult::Ok(result) => match result {
+                PlaceDeeplinkResult::Ok(()) => StepResult::Ok(()),
+                PlaceDeeplinkResult::Err(error) => match error {
+                    PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
+                        StepResult::Err(error.into())
+                    }
+                    PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
+                },
+            },
+            OpenResult::Err(_) => {
+                token.cancel();
+                StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
+            }
+        }
+    }
 }
 
 impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
@@ -490,10 +543,7 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
             return Ok(true);
         };
 
-        let use_bridge = self
-            .app_launch_step
-            .should_use_deeplink_bridge_for(&deeplink)
-            .await?;
+        let use_bridge = self.should_use_deeplink_bridge_for(&deeplink).await?;
         Ok(!use_bridge)
     }
 
@@ -512,8 +562,7 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
             return StepResultTyped::Ok(false);
         };
 
-        self.app_launch_step
-            .execute_passthrough_internal(channel, &deeplink)
+        self.execute_passthrough_internal(channel, &deeplink)
             .await?;
         StepResultTyped::Ok(true)
     }

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -82,9 +82,9 @@ pub struct LaunchFlow {
 
 impl LaunchFlow {
     pub fn new(
-        installs_hub: Arc<Mutex<InstallsHub>>,
+        installs_hub: &Arc<Mutex<InstallsHub>>,
         analytics: Arc<Mutex<Analytics>>,
-        running_instances: Arc<Mutex<RunningInstances>>,
+        running_instances: &Arc<Mutex<RunningInstances>>,
     ) -> Self {
         let app_launch_step = AppLaunchStep {
             installs_hub: installs_hub.clone(),

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -558,8 +558,13 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
         match Protocol::value() {
             Some(deeplink) => {
                 if self.should_use_deeplink_bridge_for(&deeplink).await? {
+                    log::info!("[deeplink-debug] AppLaunchStep: bridging deeplink to running instance (no new instance)");
                     execute_passthrough(channel, &deeplink).await
                 } else {
+                    log::info!(
+                        "[deeplink-debug] AppLaunchStep: launching NEW Explorer instance for deeplink {:?}",
+                        deeplink.original()
+                    );
                     self.installs_hub
                         .lock()
                         .await

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -498,15 +498,10 @@ impl DeeplinkPassthroughStep {
 impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
     async fn is_complete(&self, _: Arc<Mutex<LaunchFlowState>>) -> Result<bool> {
         let Some(deeplink) = Protocol::value() else {
-            log::info!("DeeplinkPassthroughStep::is_complete: no deeplink present, step is complete (skipped)");
             return Ok(true);
         };
 
         let use_bridge = self.should_use_deeplink_bridge_for(&deeplink).await?;
-        log::info!(
-            "DeeplinkPassthroughStep::is_complete: use_bridge={use_bridge} -> step will {}",
-            if use_bridge { "RUN passthrough (bridge)" } else { "be SKIPPED (fall through to fetch/install/launch)" }
-        );
         Ok(!use_bridge)
     }
 
@@ -522,11 +517,9 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
         _: Arc<Mutex<LaunchFlowState>>,
     ) -> StepResultTyped<bool> {
         let Some(deeplink) = Protocol::value() else {
-            log::info!("DeeplinkPassthroughStep::execute: no deeplink present, returning handled=false");
             return StepResultTyped::Ok(false);
         };
 
-        log::info!("DeeplinkPassthroughStep::execute: running bridge passthrough for deeplink {:?}", deeplink.original());
         execute_passthrough(channel, &deeplink).await?;
         StepResultTyped::Ok(true)
     }
@@ -565,13 +558,8 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
         match Protocol::value() {
             Some(deeplink) => {
                 if self.should_use_deeplink_bridge_for(&deeplink).await? {
-                    log::info!("AppLaunchStep::execute: bridge path chosen, running passthrough (NOT launching a new instance)");
                     execute_passthrough(channel, &deeplink).await
                 } else {
-                    log::info!(
-                        "AppLaunchStep::execute: bridge NOT chosen -> LAUNCHING A NEW Explorer instance with deeplink {:?}",
-                        deeplink.original()
-                    );
                     self.installs_hub
                         .lock()
                         .await
@@ -581,7 +569,6 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
                 }
             }
             None => {
-                log::info!("AppLaunchStep::execute: no deeplink present -> launching Explorer normally (new instance)");
                 //TODO passed version if specified manually from upper flow
                 self.installs_hub
                     .lock()

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -1,10 +1,6 @@
 use crate::channel::EventChannel;
-use crate::deeplink_bridge::{
-    PlaceDeeplinkError, PlaceDeeplinkResult, place_deeplink_and_wait_until_consumed,
-};
-use crate::environment::{ARG_LOCAL_SCENE, ARG_MULTI_INSTANCE, ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE, ARG_BRIDGE_ONLY};
+use crate::deeplink_bridge::{execute_passthrough, should_use_deeplink_bridge_for as should_use_bridge_for_deeplink};
 use crate::errors::{AttemptError, StepError, StepResultTyped};
-use crate::environment::Args;
 use crate::instances::RunningInstances;
 use crate::protocols::{DeepLink, Protocol};
 use crate::{
@@ -18,11 +14,8 @@ use crate::{
 use anyhow::{Context, Ok, Result, anyhow};
 use log::info;
 use regex::Regex;
-use std::time::Duration;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
-use tokio::time::error::Elapsed;
-use tokio_util::sync::CancellationToken;
 
 trait WorkflowStep<TState, TOutput> {
     async fn is_complete(&self, state: Arc<Mutex<TState>>) -> Result<bool>;
@@ -494,45 +487,8 @@ impl DeeplinkPassthroughStep {
     }
 
     async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
-        let args = AppEnvironment::cmd_args();
         let any_is_running = self.is_any_instance_running().await?;
-        Ok(should_use_deeplink_bridge(deeplink, &args, any_is_running))
-    }
-
-    async fn execute_passthrough_internal<T: EventChannel>(
-        &self,
-        channel: &T,
-        deeplink: &DeepLink,
-    ) -> StepResult {
-        const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
-        type OpenResult = std::result::Result<PlaceDeeplinkResult, Elapsed>;
-
-        channel.send(Status::State {
-            step: Step::DeeplinkOpening,
-        })?;
-
-        let token = CancellationToken::new();
-
-        match tokio::time::timeout(
-            OPEN_DEEPLINK_TIMEOUT,
-            place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
-        )
-        .await
-        {
-            OpenResult::Ok(result) => match result {
-                PlaceDeeplinkResult::Ok(()) => StepResult::Ok(()),
-                PlaceDeeplinkResult::Err(error) => match error {
-                    PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
-                        StepResult::Err(error.into())
-                    }
-                    PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
-                },
-            },
-            OpenResult::Err(_) => {
-                token.cancel();
-                StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
-            }
-        }
+        should_use_bridge_for_deeplink(deeplink, any_is_running).await
     }
 }
 
@@ -561,22 +517,9 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
             return StepResultTyped::Ok(false);
         };
 
-        self.execute_passthrough_internal(channel, &deeplink)
-            .await?;
+        execute_passthrough(channel, &deeplink).await?;
         StepResultTyped::Ok(true)
     }
-}
-
-/// Return whether an incoming deeplink should be handed off to an already-running
-/// Explorer through the file bridge instead of launching a fresh client.
-fn should_use_deeplink_bridge(deeplink: &DeepLink, args: &Args, any_is_running: bool) -> bool {
-    let open_new_instance = deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)
-        || deeplink.has_true_value(ARG_MULTI_INSTANCE)
-        || args.open_new_client_instance;
-    let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
-    let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || args.bridge_only;
-
-    !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
 }
 
 impl AppLaunchStep {
@@ -586,45 +529,8 @@ impl AppLaunchStep {
     }
 
     async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
-        let args = AppEnvironment::cmd_args();
         let any_is_running = self.is_any_instance_running().await?;
-        Ok(should_use_deeplink_bridge(deeplink, &args, any_is_running))
-    }
-
-    async fn execute_passthrough_internal<T: EventChannel>(
-        &self,
-        channel: &T,
-        deeplink: &DeepLink,
-    ) -> StepResult {
-        const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
-        type OpenResult = std::result::Result<PlaceDeeplinkResult, Elapsed>;
-
-        channel.send(Status::State {
-            step: Step::DeeplinkOpening,
-        })?;
-
-        let token = CancellationToken::new();
-
-        match tokio::time::timeout(
-            OPEN_DEEPLINK_TIMEOUT,
-            place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
-        )
-        .await
-        {
-            OpenResult::Ok(result) => match result {
-                PlaceDeeplinkResult::Ok(()) => StepResult::Ok(()),
-                PlaceDeeplinkResult::Err(error) => match error {
-                    PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
-                        StepResult::Err(error.into())
-                    }
-                    PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
-                },
-            },
-            OpenResult::Err(_) => {
-                token.cancel();
-                StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
-            }
-        }
+        should_use_bridge_for_deeplink(deeplink, any_is_running).await
     }
 }
 
@@ -649,7 +555,7 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
         match Protocol::value() {
             Some(deeplink) => {
                 if self.should_use_deeplink_bridge_for(&deeplink).await? {
-                    self.execute_passthrough_internal(channel, &deeplink).await
+                    execute_passthrough(channel, &deeplink).await
                 } else {
                     self.installs_hub
                         .lock()
@@ -706,75 +612,3 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
   const customDownloadedFilePath = getDownloadedFilePath();
 */
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashMap;
-
-    fn deeplink(flags: &[(&str, &str)]) -> DeepLink {
-        let mut map: HashMap<String, String> = HashMap::new();
-        for (key, value) in flags {
-            map.insert((*key).to_owned(), (*value).to_owned());
-        }
-        DeepLink::from_args(map)
-    }
-
-    fn args(argv: &[&str]) -> Args {
-        Args::parse(argv.iter().map(|s| (*s).to_owned()))
-    }
-
-    #[test]
-    fn uses_bridge_when_running_and_no_special_flags() {
-        assert!(should_use_deeplink_bridge(
-            &deeplink(&[]),
-            &args(&["app"]),
-            true
-        ));
-    }
-
-    #[test]
-    fn no_bridge_when_no_instance_running() {
-        assert!(!should_use_deeplink_bridge(
-            &deeplink(&[]),
-            &args(&["app"]),
-            false
-        ));
-    }
-
-    #[test]
-    fn no_bridge_when_new_instance_requested_via_deeplink() {
-        assert!(!should_use_deeplink_bridge(
-            &deeplink(&[(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE, "true")]),
-            &args(&["app"]),
-            true
-        ));
-        assert!(!should_use_deeplink_bridge(
-            &deeplink(&[(ARG_MULTI_INSTANCE, "true")]),
-            &args(&["app"]),
-            true
-        ));
-    }
-
-    #[test]
-    fn no_bridge_when_new_instance_requested_via_args() {
-        assert!(!should_use_deeplink_bridge(
-            &deeplink(&[]),
-            &args(&["app", "--open-deeplink-in-new-instance"]),
-            true
-        ));
-    }
-
-    #[test]
-    fn no_bridge_for_local_scene() {
-        assert!(!should_use_deeplink_bridge(
-            &deeplink(&[(ARG_LOCAL_SCENE, "true")]),
-            &args(&["app"]),
-            true
-        ));
-        assert!(!should_use_deeplink_bridge(
-            &deeplink(&[]),
-            &args(&["app", "--local-scene"]),
-            true
-        ));
-    }
-}

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -4,8 +4,9 @@ use crate::deeplink_bridge::{
 };
 use crate::environment::{ARG_LOCAL_SCENE, ARG_MULTI_INSTANCE, ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE};
 use crate::errors::{AttemptError, StepError, StepResultTyped};
+use crate::environment::Args;
 use crate::instances::RunningInstances;
-use crate::protocols::Protocol;
+use crate::protocols::{DeepLink, Protocol};
 use crate::{
     analytics::{Analytics, event::Event},
     environment::AppEnvironment,
@@ -73,6 +74,7 @@ pub struct LaunchFlow {
     fetch_step: FetchStep,
     download_step: DownloadStep,
     install_step: InstallStep,
+    deeplink_passthrough_step: DeeplinkPassthroughStep<AppLaunchStep>,
     app_launch_step: AppLaunchStep,
 
     analytics: Arc<Mutex<Analytics>>,
@@ -84,6 +86,11 @@ impl LaunchFlow {
         analytics: Arc<Mutex<Analytics>>,
         running_instances: Arc<Mutex<RunningInstances>>,
     ) -> Self {
+        let app_launch_step = AppLaunchStep {
+            installs_hub: installs_hub.clone(),
+            running_instances: running_instances.clone(),
+        };
+
         Self {
             fetch_step: FetchStep {},
             download_step: DownloadStep {
@@ -93,10 +100,10 @@ impl LaunchFlow {
                 analytics: analytics.clone(),
                 running_instances: running_instances.clone(),
             },
-            app_launch_step: AppLaunchStep {
-                installs_hub,
-                running_instances,
+            deeplink_passthrough_step: DeeplinkPassthroughStep {
+                handler: app_launch_step.clone(),
             },
+            app_launch_step,
             analytics,
         }
     }
@@ -160,6 +167,14 @@ impl LaunchFlow {
         channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
     ) -> StepResult {
+        let handled_by_passthrough = self
+            .deeplink_passthrough_step
+            .execute_if_needed(channel, state.clone(), "launch")
+            .await?;
+        if handled_by_passthrough.unwrap_or(false) {
+            return StepResult::Ok(());
+        }
+
         self.fetch_step
             .execute_if_needed(channel, state.clone(), "fetch")
             .await?;
@@ -442,15 +457,133 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
     }
 }
 
+trait DeeplinkPassthroughHandler {
+    async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool>;
+
+    async fn execute_passthrough<T: EventChannel>(
+        &self,
+        channel: &T,
+        deeplink: &DeepLink,
+    ) -> StepResult;
+}
+
+#[derive(Clone)]
 struct AppLaunchStep {
     installs_hub: Arc<Mutex<InstallsHub>>,
     running_instances: Arc<Mutex<RunningInstances>>,
+}
+
+struct DeeplinkPassthroughStep<THandler> {
+    handler: THandler,
+}
+
+impl<THandler> WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep<THandler>
+where
+    THandler: DeeplinkPassthroughHandler,
+{
+    async fn is_complete(&self, _: Arc<Mutex<LaunchFlowState>>) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn start_label(&self) -> Result<Status> {
+        Ok(Status::State {
+            step: Step::Launching,
+        })
+    }
+
+    async fn execute<T: EventChannel>(
+        &self,
+        channel: &T,
+        _: Arc<Mutex<LaunchFlowState>>,
+    ) -> StepResultTyped<bool> {
+        let Some(deeplink) = Protocol::value() else {
+            return StepResultTyped::Ok(false);
+        };
+
+        if self.handler.should_use_deeplink_bridge_for(&deeplink).await? {
+            self.handler.execute_passthrough(channel, &deeplink).await?;
+            return StepResultTyped::Ok(true);
+        }
+
+        StepResultTyped::Ok(false)
+    }
+}
+
+/// Whether an incoming deeplink should be handed off to an already-running Explorer
+/// through the file bridge instead of launching a fresh client.
+///
+/// This is the exact condition that also puts the launcher into windowless pass-through
+/// mode: the user clicked a `decentraland://` link while a client is running, and they
+/// did not ask for a new instance or a local scene.
+fn should_use_deeplink_bridge(deeplink: &DeepLink, args: &Args, any_is_running: bool) -> bool {
+    let open_new_instance = deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)
+        || deeplink.has_true_value(ARG_MULTI_INSTANCE)
+        || args.open_new_client_instance;
+    let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
+
+    !open_new_instance && any_is_running && !is_local_scene
 }
 
 impl AppLaunchStep {
     async fn is_any_instance_running(&self) -> anyhow::Result<bool> {
         let guard = self.running_instances.lock().await;
         guard.any_is_running()
+    }
+
+    async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
+        let args = AppEnvironment::cmd_args();
+        let any_is_running = self.is_any_instance_running().await?;
+        Ok(should_use_deeplink_bridge(deeplink, &args, any_is_running))
+    }
+
+    async fn execute_passthrough_internal<T: EventChannel>(
+        &self,
+        channel: &T,
+        deeplink: &DeepLink,
+    ) -> StepResult {
+        const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
+        type OpenResult = std::result::Result<PlaceDeeplinkResult, Elapsed>;
+
+        channel.send(Status::State {
+            step: Step::DeeplinkOpening,
+        })?;
+
+        let token = CancellationToken::new();
+
+        match tokio::time::timeout(
+            OPEN_DEEPLINK_TIMEOUT,
+            place_deeplink_and_wait_until_consumed(deeplink, token.child_token()),
+        )
+        .await
+        {
+            OpenResult::Ok(result) => match result {
+                PlaceDeeplinkResult::Ok(()) => StepResult::Ok(()),
+                PlaceDeeplinkResult::Err(error) => match error {
+                    PlaceDeeplinkError::SerializeError | PlaceDeeplinkError::IOError => {
+                        StepResult::Err(error.into())
+                    }
+                    PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
+                },
+            },
+            OpenResult::Err(_) => {
+                token.cancel();
+                StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
+            }
+        }
+    }
+}
+
+impl DeeplinkPassthroughHandler for AppLaunchStep {
+    async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
+        self.should_use_deeplink_bridge_for(deeplink).await
+    }
+
+    async fn execute_passthrough<T: EventChannel>(
+        &self,
+        channel: &T,
+        deeplink: &DeepLink,
+    ) -> StepResult {
+        self.execute_passthrough_internal(channel, deeplink).await
     }
 }
 
@@ -472,45 +605,10 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
         channel: &T,
         _state: Arc<Mutex<LaunchFlowState>>,
     ) -> StepResult {
-        const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
-        type OpenResult = std::result::Result<PlaceDeeplinkResult, Elapsed>;
-
         match Protocol::value() {
             Some(deeplink) => {
-                let args = AppEnvironment::cmd_args();
-
-                let open_new_instance = deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)
-                    || deeplink.has_true_value(ARG_MULTI_INSTANCE)
-                    || args.open_new_client_instance;
-                let any_is_running = self.is_any_instance_running().await?;
-                let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
-
-                if !open_new_instance && any_is_running && !is_local_scene {
-                    channel.send(Status::State {
-                        step: Step::DeeplinkOpening,
-                    })?;
-
-                    let token = CancellationToken::new();
-
-                    match tokio::time::timeout(
-                        OPEN_DEEPLINK_TIMEOUT,
-                        place_deeplink_and_wait_until_consumed(deeplink, token.child_token()),
-                    )
-                    .await
-                    {
-                        OpenResult::Ok(result) => match result {
-                            PlaceDeeplinkResult::Ok(()) => StepResult::Ok(()),
-                            PlaceDeeplinkResult::Err(error) => match error {
-                                PlaceDeeplinkError::SerializeError
-                                | PlaceDeeplinkError::IOError => StepResult::Err(error.into()),
-                                PlaceDeeplinkError::Cancelled => StepResult::Ok(()),
-                            },
-                        },
-                        OpenResult::Err(_) => {
-                            token.cancel();
-                            StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
-                        }
-                    }
+                if self.should_use_deeplink_bridge_for(&deeplink).await? {
+                    self.execute_passthrough_internal(channel, &deeplink).await
                 } else {
                     self.installs_hub
                         .lock()
@@ -566,3 +664,76 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
   const shouldRunDevVersion = getRunDevVersion();
   const customDownloadedFilePath = getDownloadedFilePath();
 */
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn deeplink(flags: &[(&str, &str)]) -> DeepLink {
+        let mut map: HashMap<String, String> = HashMap::new();
+        for (key, value) in flags {
+            map.insert((*key).to_owned(), (*value).to_owned());
+        }
+        DeepLink::from_args(map)
+    }
+
+    fn args(argv: &[&str]) -> Args {
+        Args::parse(argv.iter().map(|s| (*s).to_owned()))
+    }
+
+    #[test]
+    fn uses_bridge_when_running_and_no_special_flags() {
+        assert!(should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app"]),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_bridge_when_no_instance_running() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app"]),
+            false
+        ));
+    }
+
+    #[test]
+    fn no_bridge_when_new_instance_requested_via_deeplink() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE, "true")]),
+            &args(&["app"]),
+            true
+        ));
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[(ARG_MULTI_INSTANCE, "true")]),
+            &args(&["app"]),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_bridge_when_new_instance_requested_via_args() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app", "--open-deeplink-in-new-instance"]),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_bridge_for_local_scene() {
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[(ARG_LOCAL_SCENE, "true")]),
+            &args(&["app"]),
+            true
+        ));
+        assert!(!should_use_deeplink_bridge(
+            &deeplink(&[]),
+            &args(&["app", "--local-scene"]),
+            true
+        ));
+    }
+}

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -186,6 +186,9 @@ impl LaunchFlow {
         // handoff: update the deeplink bridge file and stop here instead of running the
         // fetch/download/install flow again.
         if handled_by_passthrough.unwrap_or(false) {
+            info!(
+                "Deeplink handled by passthrough (an Explorer instance is already running); skipping further steps"
+            );
             return StepResult::Ok(());
         }
 

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -558,13 +558,8 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
         match Protocol::value() {
             Some(deeplink) => {
                 if self.should_use_deeplink_bridge_for(&deeplink).await? {
-                    log::info!("[deeplink-debug] AppLaunchStep: bridging deeplink to running instance (no new instance)");
                     execute_passthrough(channel, &deeplink).await
                 } else {
-                    log::info!(
-                        "[deeplink-debug] AppLaunchStep: launching NEW Explorer instance for deeplink {:?}",
-                        deeplink.original()
-                    );
                     self.installs_hub
                         .lock()
                         .await

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -101,24 +101,6 @@ impl LaunchFlow {
         }
     }
 
-    pub async fn is_deeplink_passthrough(&self) -> bool {
-        let Some(deeplink) = Protocol::value() else {
-            return false;
-        };
-
-        match self
-            .deeplink_passthrough_step
-            .should_use_deeplink_bridge_for(&deeplink)
-            .await
-        {
-            std::result::Result::Ok(should_use_bridge) => should_use_bridge,
-            Err(error) => {
-                log::warn!("Cannot determine deeplink passthrough state: {error}");
-                false
-            }
-        }
-    }
-
     pub async fn launch<T: EventChannel>(
         &self,
         channel: &T,

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -491,7 +491,7 @@ impl DeeplinkPassthroughStep {
 
     async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
         let any_is_running = self.is_any_instance_running().await?;
-        should_use_bridge_for_deeplink(deeplink, any_is_running).await
+        Ok(should_use_bridge_for_deeplink(deeplink, any_is_running))
     }
 }
 
@@ -520,6 +520,12 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
             return StepResultTyped::Ok(false);
         };
 
+        // Re-check the bridge policy against this snapshot: an open_url event may have
+        // reassigned the protocol since `is_complete`, so decide and act on one value.
+        if !self.should_use_deeplink_bridge_for(&deeplink).await? {
+            return StepResultTyped::Ok(false);
+        }
+
         execute_passthrough(channel, &deeplink).await?;
         StepResultTyped::Ok(true)
     }
@@ -533,7 +539,7 @@ impl AppLaunchStep {
 
     async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
         let any_is_running = self.is_any_instance_running().await?;
-        should_use_bridge_for_deeplink(deeplink, any_is_running).await
+        Ok(should_use_bridge_for_deeplink(deeplink, any_is_running))
     }
 }
 

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -74,7 +74,7 @@ pub struct LaunchFlow {
     fetch_step: FetchStep,
     download_step: DownloadStep,
     install_step: InstallStep,
-    deeplink_passthrough_step: DeeplinkPassthroughStep<AppLaunchStep>,
+    deeplink_passthrough_step: DeeplinkPassthroughStep,
     app_launch_step: AppLaunchStep,
 
     analytics: Arc<Mutex<Analytics>>,
@@ -101,7 +101,7 @@ impl LaunchFlow {
                 running_instances: running_instances.clone(),
             },
             deeplink_passthrough_step: DeeplinkPassthroughStep {
-                handler: app_launch_step.clone(),
+                app_launch_step: app_launch_step.clone(),
             },
             app_launch_step,
             analytics,
@@ -457,32 +457,27 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
     }
 }
 
-trait DeeplinkPassthroughHandler {
-    async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool>;
-
-    async fn execute_passthrough<T: EventChannel>(
-        &self,
-        channel: &T,
-        deeplink: &DeepLink,
-    ) -> StepResult;
-}
-
 #[derive(Clone)]
 struct AppLaunchStep {
     installs_hub: Arc<Mutex<InstallsHub>>,
     running_instances: Arc<Mutex<RunningInstances>>,
 }
 
-struct DeeplinkPassthroughStep<THandler> {
-    handler: THandler,
+struct DeeplinkPassthroughStep {
+    app_launch_step: AppLaunchStep,
 }
 
-impl<THandler> WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep<THandler>
-where
-    THandler: DeeplinkPassthroughHandler,
-{
+impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
     async fn is_complete(&self, _: Arc<Mutex<LaunchFlowState>>) -> Result<bool> {
-        Ok(false)
+        let Some(deeplink) = Protocol::value() else {
+            return Ok(true);
+        };
+
+        let use_bridge = self
+            .app_launch_step
+            .should_use_deeplink_bridge_for(&deeplink)
+            .await?;
+        Ok(!use_bridge)
     }
 
     fn start_label(&self) -> Result<Status> {
@@ -500,12 +495,10 @@ where
             return StepResultTyped::Ok(false);
         };
 
-        if self.handler.should_use_deeplink_bridge_for(&deeplink).await? {
-            self.handler.execute_passthrough(channel, &deeplink).await?;
-            return StepResultTyped::Ok(true);
-        }
-
-        StepResultTyped::Ok(false)
+        self.app_launch_step
+            .execute_passthrough_internal(channel, &deeplink)
+            .await?;
+        StepResultTyped::Ok(true)
     }
 }
 
@@ -570,20 +563,6 @@ impl AppLaunchStep {
                 StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT)
             }
         }
-    }
-}
-
-impl DeeplinkPassthroughHandler for AppLaunchStep {
-    async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
-        self.should_use_deeplink_bridge_for(deeplink).await
-    }
-
-    async fn execute_passthrough<T: EventChannel>(
-        &self,
-        channel: &T,
-        deeplink: &DeepLink,
-    ) -> StepResult {
-        self.execute_passthrough_internal(channel, deeplink).await
     }
 }
 

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -2,7 +2,7 @@ use crate::channel::EventChannel;
 use crate::deeplink_bridge::{
     PlaceDeeplinkError, PlaceDeeplinkResult, place_deeplink_and_wait_until_consumed,
 };
-use crate::environment::{ARG_LOCAL_SCENE, ARG_MULTI_INSTANCE, ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE};
+use crate::environment::{ARG_LOCAL_SCENE, ARG_MULTI_INSTANCE, ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE, ARG_BRIDGE_ONLY};
 use crate::errors::{AttemptError, StepError, StepResultTyped};
 use crate::environment::Args;
 use crate::instances::RunningInstances;
@@ -530,8 +530,9 @@ fn should_use_deeplink_bridge(deeplink: &DeepLink, args: &Args, any_is_running: 
         || deeplink.has_true_value(ARG_MULTI_INSTANCE)
         || args.open_new_client_instance;
     let is_local_scene = deeplink.has_true_value(ARG_LOCAL_SCENE) || args.local_scene;
+    let bridge_only = deeplink.has_true_value(ARG_BRIDGE_ONLY) || args.bridge_only;
 
-    !open_new_instance && any_is_running && !is_local_scene
+    !open_new_instance && (any_is_running || bridge_only) && !is_local_scene
 }
 
 impl AppLaunchStep {

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -108,6 +108,20 @@ impl LaunchFlow {
         }
     }
 
+    pub async fn is_deeplink_passthrough(&self) -> bool {
+        let Some(deeplink) = Protocol::value() else {
+            return false;
+        };
+
+        match self.app_launch_step.should_use_deeplink_bridge_for(&deeplink).await {
+            std::result::Result::Ok(should_use_bridge) => should_use_bridge,
+            Err(error) => {
+                log::warn!("Cannot determine deeplink passthrough state: {error}");
+                false
+            }
+        }
+    }
+
     pub async fn launch<T: EventChannel>(
         &self,
         channel: &T,

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -171,6 +171,9 @@ impl LaunchFlow {
             .deeplink_passthrough_step
             .execute_if_needed(channel, state.clone(), "launch")
             .await?;
+        // If another Explorer instance is already running, treat this as a deeplink-only
+        // handoff: update the deeplink bridge file and stop here instead of running the
+        // fetch/download/install flow again.
         if handled_by_passthrough.unwrap_or(false) {
             return StepResult::Ok(());
         }
@@ -545,7 +548,7 @@ impl AppLaunchStep {
 
         match tokio::time::timeout(
             OPEN_DEEPLINK_TIMEOUT,
-            place_deeplink_and_wait_until_consumed(deeplink, token.child_token()),
+            place_deeplink_and_wait_until_consumed(deeplink.clone(), token.child_token()),
         )
         .await
         {

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -478,7 +478,6 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
     }
 }
 
-#[derive(Clone)]
 struct AppLaunchStep {
     installs_hub: Arc<Mutex<InstallsHub>>,
     running_instances: Arc<Mutex<RunningInstances>>,
@@ -568,12 +567,8 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
     }
 }
 
-/// Whether an incoming deeplink should be handed off to an already-running Explorer
-/// through the file bridge instead of launching a fresh client.
-///
-/// This is the exact condition that also puts the launcher into windowless pass-through
-/// mode: the user clicked a `decentraland://` link while a client is running, and they
-/// did not ask for a new instance or a local scene.
+/// Return whether an incoming deeplink should be handed off to an already-running
+/// Explorer through the file bridge instead of launching a fresh client.
 fn should_use_deeplink_bridge(deeplink: &DeepLink, args: &Args, any_is_running: bool) -> bool {
     let open_new_instance = deeplink.has_true_value(ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE)
         || deeplink.has_true_value(ARG_MULTI_INSTANCE)

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -498,10 +498,15 @@ impl DeeplinkPassthroughStep {
 impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
     async fn is_complete(&self, _: Arc<Mutex<LaunchFlowState>>) -> Result<bool> {
         let Some(deeplink) = Protocol::value() else {
+            log::info!("DeeplinkPassthroughStep::is_complete: no deeplink present, step is complete (skipped)");
             return Ok(true);
         };
 
         let use_bridge = self.should_use_deeplink_bridge_for(&deeplink).await?;
+        log::info!(
+            "DeeplinkPassthroughStep::is_complete: use_bridge={use_bridge} -> step will {}",
+            if use_bridge { "RUN passthrough (bridge)" } else { "be SKIPPED (fall through to fetch/install/launch)" }
+        );
         Ok(!use_bridge)
     }
 
@@ -517,9 +522,11 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
         _: Arc<Mutex<LaunchFlowState>>,
     ) -> StepResultTyped<bool> {
         let Some(deeplink) = Protocol::value() else {
+            log::info!("DeeplinkPassthroughStep::execute: no deeplink present, returning handled=false");
             return StepResultTyped::Ok(false);
         };
 
+        log::info!("DeeplinkPassthroughStep::execute: running bridge passthrough for deeplink {:?}", deeplink.original());
         execute_passthrough(channel, &deeplink).await?;
         StepResultTyped::Ok(true)
     }
@@ -558,8 +565,13 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
         match Protocol::value() {
             Some(deeplink) => {
                 if self.should_use_deeplink_bridge_for(&deeplink).await? {
+                    log::info!("AppLaunchStep::execute: bridge path chosen, running passthrough (NOT launching a new instance)");
                     execute_passthrough(channel, &deeplink).await
                 } else {
+                    log::info!(
+                        "AppLaunchStep::execute: bridge NOT chosen -> LAUNCHING A NEW Explorer instance with deeplink {:?}",
+                        deeplink.original()
+                    );
                     self.installs_hub
                         .lock()
                         .await
@@ -569,6 +581,7 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
                 }
             }
             None => {
+                log::info!("AppLaunchStep::execute: no deeplink present -> launching Explorer normally (new instance)");
                 //TODO passed version if specified manually from upper flow
                 self.installs_hub
                     .lock()

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -1,5 +1,5 @@
 use crate::channel::EventChannel;
-use crate::deeplink_bridge::{execute_passthrough, should_use_deeplink_bridge_for as should_use_bridge_for_deeplink};
+use crate::deeplink_bridge::{execute_passthrough, should_use_deeplink_bridge_for};
 use crate::errors::{AttemptError, StepError, StepResultTyped};
 use crate::instances::RunningInstances;
 use crate::protocols::{DeepLink, Protocol};
@@ -162,7 +162,7 @@ impl LaunchFlow {
     ) -> StepResult {
         let handled_by_passthrough = self
             .deeplink_passthrough_step
-            .execute_if_needed(channel, state.clone(), "launch")
+            .execute_if_needed(channel, state.clone(), "deeplink_passthrough")
             .await?;
         // If another Explorer instance is already running, treat this as a deeplink-only
         // handoff: update the deeplink bridge file and stop here instead of running the
@@ -473,7 +473,7 @@ impl DeeplinkPassthroughStep {
 
     async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
         let any_is_running = self.is_any_instance_running().await?;
-        Ok(should_use_bridge_for_deeplink(deeplink, any_is_running))
+        Ok(should_use_deeplink_bridge_for(deeplink, any_is_running))
     }
 }
 
@@ -521,7 +521,7 @@ impl AppLaunchStep {
 
     async fn should_use_deeplink_bridge_for(&self, deeplink: &DeepLink) -> anyhow::Result<bool> {
         let any_is_running = self.is_any_instance_running().await?;
-        Ok(should_use_bridge_for_deeplink(deeplink, any_is_running))
+        Ok(should_use_deeplink_bridge_for(deeplink, any_is_running))
     }
 }
 

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -53,8 +53,6 @@ impl DeepLink {
                     map.insert(key.into_owned(), value.into_owned());
                 }
 
-                log::info!("[deeplink-debug] parsed query {query:?} -> args map {map:?}");
-
                 map
             }
             None => {
@@ -65,16 +63,11 @@ impl DeepLink {
     }
 
     pub fn has_true_value(&self, key: &str) -> bool {
-        let result = if let Some(value) = self.args.get(key) {
+        if let Some(value) = self.args.get(key) {
             value == "true"
         } else {
             false
-        };
-        log::info!(
-            "[deeplink-debug] has_true_value({key:?}) = {result} (stored value: {:?})",
-            self.args.get(key)
-        );
-        result
+        }
     }
 
     pub fn original(&self) -> &str {

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -74,7 +74,7 @@ impl DeepLink {
     }
 
     #[cfg(test)]
-    pub(crate) fn from_args(args: HashMap<String, String>) -> Self {
+    pub(crate) const fn from_args(args: HashMap<String, String>) -> Self {
         Self {
             original: String::new(),
             args,

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -53,6 +53,8 @@ impl DeepLink {
                     map.insert(key.into_owned(), value.into_owned());
                 }
 
+                log::info!("[deeplink-debug] parsed query {query:?} -> args map {map:?}");
+
                 map
             }
             None => {
@@ -63,11 +65,16 @@ impl DeepLink {
     }
 
     pub fn has_true_value(&self, key: &str) -> bool {
-        if let Some(value) = self.args.get(key) {
+        let result = if let Some(value) = self.args.get(key) {
             value == "true"
         } else {
             false
-        }
+        };
+        log::info!(
+            "[deeplink-debug] has_true_value({key:?}) = {result} (stored value: {:?})",
+            self.args.get(key)
+        );
+        result
     }
 
     pub fn original(&self) -> &str {

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -11,6 +11,7 @@ const PROTOCOL_PREFIX: &str = "decentraland://";
 #[derive(Default, Clone)]
 pub struct Protocol {}
 
+#[derive(Debug)]
 pub enum DeepLinkCreateError {
     WrongPrefix { original_content: String },
 }
@@ -74,11 +75,8 @@ impl DeepLink {
     }
 
     #[cfg(test)]
-    pub(crate) const fn from_args(args: HashMap<String, String>) -> Self {
-        Self {
-            original: String::new(),
-            args,
-        }
+    pub(crate) fn from_string(value: impl Into<String>) -> Result<Self, DeepLinkCreateError> {
+        Self::new(value.into())
     }
 }
 

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -72,6 +72,14 @@ impl DeepLink {
     pub fn original(&self) -> &str {
         &self.original
     }
+
+    #[cfg(test)]
+    pub(crate) fn from_args(args: HashMap<String, String>) -> Self {
+        Self {
+            original: String::new(),
+            args,
+        }
+    }
 }
 
 impl From<DeepLink> for String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -269,8 +269,7 @@ fn setup_deeplink(a: &App, protocol: &Protocol) {
     #[cfg(target_os = "macos")]
     {
         // The deep-link plugin buffers the URL the app was launched with. When the
-        // launch URL is delivered *before* `on_open_url` is registered (the reproducible
-        // second-login case), the plugin does not replay it through the callback — it is
+        // launch URL is delivered *before* `on_open_url` is registered, the plugin does not replay it through the callback — it is
         // only retrievable here via `get_current`. Seed `Protocol` from it so the
         // deeplink is not silently lost; the `on_open_url` handler below still covers
         // URLs that arrive *after* registration.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -278,6 +278,31 @@ fn setup_deeplink(a: &App, protocol: &Protocol) {
 
     #[cfg(target_os = "macos")]
     {
+        // The deep-link plugin buffers the URL the app was launched with. When the
+        // launch URL is delivered *before* `on_open_url` is registered (the reproducible
+        // second-login case), the plugin does not replay it through the callback — it is
+        // only retrievable here via `get_current`. Seed `Protocol` from it so the
+        // deeplink is not silently lost; the `on_open_url` handler below still covers
+        // URLs that arrive *after* registration.
+        match a.deep_link().get_current() {
+            Ok(Some(urls)) => {
+                info!(
+                    "[deeplink-debug] get_current at startup: {} url(s): {:?}",
+                    urls.len(),
+                    urls
+                );
+                if let Some(url) = urls.first() {
+                    protocol.try_assign_value(url.to_string());
+                    info!(
+                        "[deeplink-debug] get_current: seeded Protocol; present now: {}",
+                        Protocol::value().is_some()
+                    );
+                }
+            }
+            Ok(None) => info!("[deeplink-debug] get_current at startup: None"),
+            Err(e) => error!("[deeplink-debug] get_current at startup failed: {}", e),
+        }
+
         let protocol = protocol.clone();
         a.deep_link().on_open_url(move |event| {
             let urls = event.urls();
@@ -299,20 +324,6 @@ fn setup_deeplink(a: &App, protocol: &Protocol) {
                 }
             }
         });
-
-        // Belt-and-suspenders: the plugin also buffers the URL the app was launched
-        // with. If `on_open_url` never fires on a cold relaunch, this tells us whether
-        // the OS handed the URL to the process at all (empty here == lost at the OS
-        // layer, before the launcher could see it).
-        match a.deep_link().get_current() {
-            Ok(Some(urls)) => info!(
-                "[deeplink-debug] get_current at startup: {} url(s): {:?}",
-                urls.len(),
-                urls
-            ),
-            Ok(None) => info!("[deeplink-debug] get_current at startup: None"),
-            Err(e) => error!("[deeplink-debug] get_current at startup failed: {}", e),
-        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -299,6 +299,20 @@ fn setup_deeplink(a: &App, protocol: &Protocol) {
                 }
             }
         });
+
+        // Belt-and-suspenders: the plugin also buffers the URL the app was launched
+        // with. If `on_open_url` never fires on a cold relaunch, this tells us whether
+        // the OS handed the URL to the process at all (empty here == lost at the OS
+        // layer, before the launcher could see it).
+        match a.deep_link().get_current() {
+            Ok(Some(urls)) => info!(
+                "[deeplink-debug] get_current at startup: {} url(s): {:?}",
+                urls.len(),
+                urls
+            ),
+            Ok(None) => info!("[deeplink-debug] get_current at startup: None"),
+            Err(e) => error!("[deeplink-debug] get_current at startup failed: {}", e),
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,11 +106,6 @@ async fn launch_internal(
 
     let flow_state = guard.state.clone();
 
-    info!(
-        "[deeplink-debug] launch invoked; deeplink present at launch time: {}",
-        Protocol::value().is_some()
-    );
-
     // When a deeplink arrives while the Explorer is already running, run windowless:
     // don't show the launcher window and don't check for launcher updates — just pass
     // the deeplink through to the running client.
@@ -269,12 +264,7 @@ async fn update_if_needed_and_restart(
 fn setup_deeplink(a: &App, protocol: &Protocol) {
     // Support reading from cmd args on both macOS and Windows
     let args: Vec<String> = AppEnvironment::raw_cmd_args().collect();
-    info!("[deeplink-debug] setup_deeplink: raw cmd args: {:?}", args);
     protocol.try_assign_value_from_vec(&args);
-    info!(
-        "[deeplink-debug] setup_deeplink: deeplink present after argv parse: {}",
-        Protocol::value().is_some()
-    );
 
     #[cfg(target_os = "macos")]
     {
@@ -286,38 +276,20 @@ fn setup_deeplink(a: &App, protocol: &Protocol) {
         // URLs that arrive *after* registration.
         match a.deep_link().get_current() {
             Ok(Some(urls)) => {
-                info!(
-                    "[deeplink-debug] get_current at startup: {} url(s): {:?}",
-                    urls.len(),
-                    urls
-                );
                 if let Some(url) = urls.first() {
                     protocol.try_assign_value(url.to_string());
-                    info!(
-                        "[deeplink-debug] get_current: seeded Protocol; present now: {}",
-                        Protocol::value().is_some()
-                    );
                 }
             }
-            Ok(None) => info!("[deeplink-debug] get_current at startup: None"),
-            Err(e) => error!("[deeplink-debug] get_current at startup failed: {}", e),
+            Ok(None) => {}
+            Err(e) => error!("Failed to read launch deeplink via get_current: {}", e),
         }
 
         let protocol = protocol.clone();
         a.deep_link().on_open_url(move |event| {
             let urls = event.urls();
-            info!(
-                "[deeplink-debug] on_open_url fired with {} url(s): {:?}",
-                urls.len(),
-                urls
-            );
             match urls.first() {
                 Some(url) => {
                     protocol.try_assign_value(url.to_string());
-                    info!(
-                        "[deeplink-debug] on_open_url: assigned deeplink; present now: {}",
-                        Protocol::value().is_some()
-                    );
                 }
                 None => {
                     error!("No values are provided in deep link");
@@ -347,29 +319,12 @@ fn setup(a: &mut App) -> std::result::Result<(), Box<dyn std::error::Error>> {
 #[allow(clippy::expect_used)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let app = tauri::Builder::default()
+    tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_deep_link::init())
         .setup(setup)
         .invoke_handler(tauri::generate_handler![launch, retry])
-        .build(tauri::generate_context!())
+        .run(tauri::generate_context!())
         .expect("error while running tauri application");
-
-    app.run(move |_app_handle, event| {
-        // [deeplink-debug] macOS can also deliver deeplinks through the run loop
-        // (RunEvent::Opened), which the launcher currently does not consume. Log it
-        // so we can tell whether the second-login deeplink arrives here instead of
-        // (or in addition to) `on_open_url`.
-        #[cfg(target_os = "macos")]
-        if let tauri::RunEvent::Opened { urls } = &event {
-            info!(
-                "[deeplink-debug] RunEvent::Opened received with {} url(s): {:?}",
-                urls.len(),
-                urls
-            );
-        }
-        #[cfg(not(target_os = "macos"))]
-        let _ = &event;
-    });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,11 @@ async fn launch_internal(
 
     let flow_state = guard.state.clone();
 
+    info!(
+        "[deeplink-debug] launch invoked; deeplink present at launch time: {}",
+        Protocol::value().is_some()
+    );
+
     // When a deeplink arrives while the Explorer is already running, run windowless:
     // don't show the launcher window and don't check for launcher updates — just pass
     // the deeplink through to the running client.
@@ -264,16 +269,30 @@ async fn update_if_needed_and_restart(
 fn setup_deeplink(a: &App, protocol: &Protocol) {
     // Support reading from cmd args on both macOS and Windows
     let args: Vec<String> = AppEnvironment::raw_cmd_args().collect();
+    info!("[deeplink-debug] setup_deeplink: raw cmd args: {:?}", args);
     protocol.try_assign_value_from_vec(&args);
+    info!(
+        "[deeplink-debug] setup_deeplink: deeplink present after argv parse: {}",
+        Protocol::value().is_some()
+    );
 
     #[cfg(target_os = "macos")]
     {
         let protocol = protocol.clone();
         a.deep_link().on_open_url(move |event| {
             let urls = event.urls();
+            info!(
+                "[deeplink-debug] on_open_url fired with {} url(s): {:?}",
+                urls.len(),
+                urls
+            );
             match urls.first() {
                 Some(url) => {
                     protocol.try_assign_value(url.to_string());
+                    info!(
+                        "[deeplink-debug] on_open_url: assigned deeplink; present now: {}",
+                        Protocol::value().is_some()
+                    );
                 }
                 None => {
                     error!("No values are provided in deep link");
@@ -303,12 +322,29 @@ fn setup(a: &mut App) -> std::result::Result<(), Box<dyn std::error::Error>> {
 #[allow(clippy::expect_used)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_deep_link::init())
         .setup(setup)
         .invoke_handler(tauri::generate_handler![launch, retry])
-        .run(tauri::generate_context!())
+        .build(tauri::generate_context!())
         .expect("error while running tauri application");
+
+    app.run(move |_app_handle, event| {
+        // [deeplink-debug] macOS can also deliver deeplinks through the run loop
+        // (RunEvent::Opened), which the launcher currently does not consume. Log it
+        // so we can tell whether the second-login deeplink arrives here instead of
+        // (or in addition to) `on_open_url`.
+        #[cfg(target_os = "macos")]
+        if let tauri::RunEvent::Opened { urls } = &event {
+            info!(
+                "[deeplink-debug] RunEvent::Opened received with {} url(s): {:?}",
+                urls.len(),
+                urls
+            );
+        }
+        #[cfg(not(target_os = "macos"))]
+        let _ = &event;
+    });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,19 +83,6 @@ async fn launch(
     launch_internal(app, state, channel).await
 }
 
-fn show_main_window(app: &AppHandle) {
-    let Some(window) = app.get_webview_window("main") else {
-        error!("Cannot find main window to show");
-        return;
-    };
-    if let Err(e) = window.show() {
-        error!("Failed to show main window: {}", e);
-    }
-    if let Err(e) = window.set_focus() {
-        error!("Failed to focus main window: {}", e);
-    }
-}
-
 async fn launch_internal(
     app: AppHandle,
     state: State<'_, MutState>,
@@ -106,19 +93,8 @@ async fn launch_internal(
 
     let flow_state = guard.state.clone();
 
-    // When a deeplink arrives while the Explorer is already running, run windowless:
-    // don't show the launcher window and don't check for launcher updates — just pass
-    // the deeplink through to the running client.
-    let windowless = guard.flow.is_deeplink_passthrough().await;
-
-    if windowless {
-        info!("Deeplink pass-through to a running Explorer detected; running windowless (no window, skipping update check)");
-    } else {
-        show_main_window(&app);
-
-        if let Err(e) = update_if_needed_and_restart(&app, &guard, &status_channel).await {
-            error!("Cannot update the launcher: {}", e);
-        }
+    if let Err(e) = update_if_needed_and_restart(&app, &guard, &status_channel).await {
+        error!("Cannot update the launcher: {}", e);
     }
 
     guard
@@ -126,11 +102,6 @@ async fn launch_internal(
         .launch(&status_channel, flow_state)
         .await
         .map_err(|e| {
-            // The silent pass-through failed (e.g. the deeplink timed out): reveal the
-            // window so the user actually sees the error instead of nothing happening.
-            if windowless {
-                show_main_window(&app);
-            }
             status_channel.notify_error(&e);
             e.user_message
         })?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,22 @@ async fn launch(
     launch_internal(app, state, channel).await
 }
 
+/// Show and focus the launcher's main window. The window starts hidden (see
+/// `tauri.conf.json`) so that pure deeplink pass-throughs to a running Explorer stay
+/// windowless; every other path reveals it here.
+fn show_main_window(app: &AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        error!("Cannot find main window to show");
+        return;
+    };
+    if let Err(e) = window.show() {
+        error!("Failed to show main window: {}", e);
+    }
+    if let Err(e) = window.set_focus() {
+        error!("Failed to focus main window: {}", e);
+    }
+}
+
 async fn launch_internal(
     app: AppHandle,
     state: State<'_, MutState>,
@@ -93,8 +109,19 @@ async fn launch_internal(
 
     let flow_state = guard.state.clone();
 
-    if let Err(e) = update_if_needed_and_restart(&app, &guard, &status_channel).await {
-        error!("Cannot update the launcher: {}", e);
+    // When a deeplink arrives while the Explorer is already running, run windowless:
+    // don't show the launcher window and don't check for launcher updates — just pass
+    // the deeplink through to the running client.
+    let windowless = guard.flow.is_deeplink_passthrough().await;
+
+    if windowless {
+        info!("Deeplink pass-through to a running Explorer detected; running windowless (no window, skipping update check)");
+    } else {
+        show_main_window(&app);
+
+        if let Err(e) = update_if_needed_and_restart(&app, &guard, &status_channel).await {
+            error!("Cannot update the launcher: {}", e);
+        }
     }
 
     guard
@@ -102,6 +129,11 @@ async fn launch_internal(
         .launch(&status_channel, flow_state)
         .await
         .map_err(|e| {
+            // The silent pass-through failed (e.g. the deeplink timed out): reveal the
+            // window so the user actually sees the error instead of nothing happening.
+            if windowless {
+                show_main_window(&app);
+            }
             status_channel.notify_error(&e);
             e.user_message
         })?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,9 +83,6 @@ async fn launch(
     launch_internal(app, state, channel).await
 }
 
-/// Show and focus the launcher's main window. The window starts hidden (see
-/// `tauri.conf.json`) so that pure deeplink pass-throughs to a running Explorer stay
-/// windowless; every other path reveals it here.
 fn show_main_window(app: &AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
         error!("Cannot find main window to show");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,11 +239,8 @@ fn setup_deeplink(a: &App, protocol: &Protocol) {
 
     #[cfg(target_os = "macos")]
     {
-        // The deep-link plugin buffers the URL the app was launched with. When the
-        // launch URL is delivered *before* `on_open_url` is registered, the plugin does not replay it through the callback — it is
-        // only retrievable here via `get_current`. Seed `Protocol` from it so the
-        // deeplink is not silently lost; the `on_open_url` handler below still covers
-        // URLs that arrive *after* registration.
+        // consume deeplink from current in case already exists
+        // which will provoke that on_open_url not be triggered
         match a.deep_link().get_current() {
             Ok(Some(urls)) => {
                 if let Some(url) = urls.first() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,11 +13,13 @@
   "app": {
     "windows": [
       {
+        "label": "main",
         "title": "Decentraland",
         "width": 600,
         "height": 156,
         "resizable": false,
-        "center": true
+        "center": true,
+        "visible": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,13 +13,11 @@
   "app": {
     "windows": [
       {
-        "label": "main",
         "title": "Decentraland",
         "width": 600,
         "height": 156,
         "resizable": false,
-        "center": true,
-        "visible": false
+        "center": true
       }
     ],
     "security": {


### PR DESCRIPTION
### Problem: Login via browser deep-link opens Launcher instead of Explorer

When logging in from the desktop client, the browser-based auth flow redirects back to the app via a deep-link. However, the deep-link targets the **Launcher**, not the running **Explorer** instance, causing several problems:

1. After accepting the login in the browser, the OS prompts the user to open the Decentraland app — even though Explorer is already running.
2. If the user **cancels** the prompt, the login in the already-open Explorer hangs (intermittent loading spinner) and never completes. There is no recovery path or feedback to the user.
3. If the user **accepts**, a new Launcher instance opens and may start downloading/updating (e.g., when the local build isn't the latest release), which is confusing.

### Solution

- When a `decentraland://` deeplink is received while an Explorer instance is already running, the launcher forwards the deeplink through the bridge file and skips the update/launch flow instead of re-running it. Applies only on `bridgeOnly` mode. The startup is now faster, showing the launcher for less than 5 seconds, removing the UX friction.
- A `&bridgeOnly` param has been added that prevents the launcher to open an Explorer instance. Useful when logging through Unity Editor.
- Pre-existent bug: Consume the deeplink from the current state, in addition to the `open_url` event. When the launcher is fired the 2nd time (on login -> use different account flow), the deeplink is already there, and the event doesn't trigger.

### Test steps

1. Download the build from this pr: https://github.com/decentraland/unity-explorer/pull/9100
2. Place it at `~/Library/Application Support/DecentralandLauncherLight/latest` (mac, windows needs another path)
3. Edit the file `'~/Application Support/DecentralandLauncherLight/config.json'
4. Add the line so the launcher doesn't update and gets overridden: `"cmd-arguments": "--never-trigger-updater"`
Example:
```
{
  "analytics-user-id": ".....",
  "cmd-arguments": "--never-trigger-updater"
}
```
5. Install this launcher
6. Close it
7. Rerun it on `zone` env as: decentraland://?dclenv=zone
8. Logout from any account
9. Login with Metamask or Google keeping the Explorer opened
10. Go to the auth website, check that the url has the `deeplink` query param
11. Sign the authentication
12. Wait until you are redirected
13. Click yes to open Decentraland
14. The launcher should open quickly and immediately redirect you to the Explorer, no update checks, no download steps
15. Check that the login flow works with multiple running instances by opening it: `decentraland://?dclenv=zone&multi-instance=true`