### PR TITLE
feat: add DEV installer publish workflow for client-download-gateway

### DIFF
--- a/.github/workflows/publish-dev-installer.yml
+++ b/.github/workflows/publish-dev-installer.yml
@@ -1,0 +1,52 @@
+name: Publish DEV installer for client-download-gateway
+# Promotes a PR's dry-run build to the keys client-download-gateway serves on .zone.
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "launcher-rust PR number (from the build comment)"
+        required: true
+      run:
+        description: "run-<num>-<id> folder; blank = latest for that PR"
+        required: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.DEV_EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.DEV_EXPLORER_TEAM_AWS_DEFAULT_REGION }}
+      S3_BUCKET: ${{ secrets.DEV_EXPLORER_TEAM_S3_BUCKET }}
+    steps:
+      - name: Copy dry-run installer onto gateway serving keys
+        env:
+          PR: ${{ inputs.pr }}
+          RUN: ${{ inputs.run }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          [[ "$PR" =~ ^[0-9]+$ ]] || { echo "invalid pr: $PR"; exit 1; }
+          [[ -z "$RUN" || "$RUN" =~ ^run-[0-9]+-[0-9]+$ ]] || { echo "invalid run: $RUN"; exit 1; }
+          FILES="Decentraland_installer.exe Decentraland_installer.dmg dcl_launcher.exe"
+          SRC="dry-run-${REPO}/pr-${PR}"
+          if [ -z "$RUN" ]; then
+            RUN=$(aws s3api list-objects-v2 --bucket "$S3_BUCKET" --prefix "$SRC/" \
+                    --query 'sort_by(Contents,&LastModified)[-1].Key' --output text | awk -F/ '{print $3}')
+          fi
+          if [ -z "$RUN" ] || [ "$RUN" = "None" ]; then echo "No build found under $SRC/"; exit 1; fi
+          FROM="s3://$S3_BUCKET/$SRC/$RUN"
+          TO="s3://$S3_BUCKET/zone-downloader-launcher-rust"
+
+          # Bucket is unversioned, so snapshot current objects before overwriting.
+          ARCHIVE="$TO/_prev/$(date -u +%Y%m%dT%H%M%SZ)"
+          for f in $FILES; do
+            aws s3 cp "$TO/$f" "$ARCHIVE/$f" --only-show-errors || echo "no existing $f to back up"
+          done
+
+          for f in $FILES; do
+            aws s3 cp "$FROM/$f" "$TO/$f" --only-show-errors
+          done
+          echo "Published run $RUN."

--- a/.github/workflows/publish-dev-installer.yml
+++ b/.github/workflows/publish-dev-installer.yml
@@ -10,6 +10,10 @@ on:
         description: "run-<num>-<id> folder; blank = latest for that PR"
         required: false
 
+concurrency:
+  group: publish-dev-installer
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -37,16 +41,28 @@ jobs:
                     --query 'sort_by(Contents,&LastModified)[-1].Key' --output text | awk -F/ '{print $3}')
           fi
           if [ -z "$RUN" ] || [ "$RUN" = "None" ]; then echo "No build found under $SRC/"; exit 1; fi
-          FROM="s3://$S3_BUCKET/$SRC/$RUN"
-          TO="s3://$S3_BUCKET/zone-downloader-launcher-rust"
+          SRC_PREFIX="$SRC/$RUN"
+          DEST_PREFIX="zone-downloader-launcher-rust"
+          ARCHIVE_PREFIX="$DEST_PREFIX/_prev/$(date -u +%Y%m%dT%H%M%SZ)"
 
-          # Bucket is unversioned, so snapshot current objects before overwriting.
-          ARCHIVE="$TO/_prev/$(date -u +%Y%m%dT%H%M%SZ)"
+          # Preflight sources so a mid-run failure can't leave a mixed old/new set on the live keys.
           for f in $FILES; do
-            aws s3 cp "$TO/$f" "$ARCHIVE/$f" --only-show-errors || echo "no existing $f to back up"
+            aws s3api head-object --bucket "$S3_BUCKET" --key "$SRC_PREFIX/$f" >/dev/null \
+              || { echo "missing source object: $SRC_PREFIX/$f"; exit 1; }
+          done
+
+          # Unversioned bucket: back up before overwrite; skip only on 404, fail on any other error.
+          for f in $FILES; do
+            if err=$(aws s3api head-object --bucket "$S3_BUCKET" --key "$DEST_PREFIX/$f" 2>&1); then
+              aws s3 cp "s3://$S3_BUCKET/$DEST_PREFIX/$f" "s3://$S3_BUCKET/$ARCHIVE_PREFIX/$f" --only-show-errors
+            elif printf '%s' "$err" | grep -q '(404)'; then
+              echo "no existing $f to back up"
+            else
+              printf '%s\n' "$err"; exit 1
+            fi
           done
 
           for f in $FILES; do
-            aws s3 cp "$FROM/$f" "$TO/$f" --only-show-errors
+            aws s3 cp "s3://$S3_BUCKET/$SRC_PREFIX/$f" "s3://$S3_BUCKET/$DEST_PREFIX/$f" --only-show-errors
           done
           echo "Published run $RUN."

--- a/.github/workflows/publish-dev-installer.yml
+++ b/.github/workflows/publish-dev-installer.yml
@@ -33,14 +33,14 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$PR" =~ ^[0-9]+$ ]] || { echo "invalid pr: $PR"; exit 1; }
-          [[ -z "$RUN" || "$RUN" =~ ^run-[0-9]+-[0-9]+$ ]] || { echo "invalid run: $RUN"; exit 1; }
           FILES="Decentraland_installer.exe Decentraland_installer.dmg dcl_launcher.exe"
           SRC="dry-run-${REPO}/pr-${PR}"
           if [ -z "$RUN" ]; then
             RUN=$(aws s3api list-objects-v2 --bucket "$S3_BUCKET" --prefix "$SRC/" \
-                    --query 'sort_by(Contents,&LastModified)[-1].Key' --output text | awk -F/ '{print $3}')
+                    --query 'sort_by(Contents || `[]`, &LastModified)[-1].Key' --output text | awk -F/ '{print $3}') || RUN=""
           fi
-          if [ -z "$RUN" ] || [ "$RUN" = "None" ]; then echo "No build found under $SRC/"; exit 1; fi
+          # Validate whether the run was provided or auto-discovered.
+          [[ "$RUN" =~ ^run-[0-9]+-[0-9]+$ ]] || { echo "invalid or undiscoverable run: '$RUN'"; exit 1; }
           SRC_PREFIX="$SRC/$RUN"
           DEST_PREFIX="zone-downloader-launcher-rust"
           ARCHIVE_PREFIX="$DEST_PREFIX/_prev/$(date -u +%Y%m%dT%H%M%SZ)"
@@ -52,9 +52,11 @@ jobs:
           done
 
           # Unversioned bucket: back up before overwrite; skip only on 404, fail on any other error.
+          BACKED_UP=""
           for f in $FILES; do
             if err=$(aws s3api head-object --bucket "$S3_BUCKET" --key "$DEST_PREFIX/$f" 2>&1); then
               aws s3 cp "s3://$S3_BUCKET/$DEST_PREFIX/$f" "s3://$S3_BUCKET/$ARCHIVE_PREFIX/$f" --only-show-errors
+              BACKED_UP="$BACKED_UP $f"
             elif printf '%s' "$err" | grep -q '(404)'; then
               echo "no existing $f to back up"
             else
@@ -62,7 +64,27 @@ jobs:
             fi
           done
 
+          # Overwriting the live keys is not atomic; restore this run's archive on any publish/verify failure.
+          rollback() {
+            echo "Publish failed — restoring previous live keys."
+            for f in $FILES; do
+              case " $BACKED_UP " in
+                *" $f "*) aws s3 cp "s3://$S3_BUCKET/$ARCHIVE_PREFIX/$f" "s3://$S3_BUCKET/$DEST_PREFIX/$f" --only-show-errors || echo "rollback failed for $f" ;;
+                *)        aws s3 rm "s3://$S3_BUCKET/$DEST_PREFIX/$f" --only-show-errors || true ;;
+              esac
+            done
+          }
+          trap rollback ERR
+
           for f in $FILES; do
             aws s3 cp "s3://$S3_BUCKET/$SRC_PREFIX/$f" "s3://$S3_BUCKET/$DEST_PREFIX/$f" --only-show-errors
           done
+
+          for f in $FILES; do
+            src_size=$(aws s3api head-object --bucket "$S3_BUCKET" --key "$SRC_PREFIX/$f" --query ContentLength --output text)
+            dest_size=$(aws s3api head-object --bucket "$S3_BUCKET" --key "$DEST_PREFIX/$f" --query ContentLength --output text)
+            [ "$src_size" = "$dest_size" ] || { echo "size mismatch for $f: src=$src_size dest=$dest_size"; false; }
+          done
+
+          trap - ERR
           echo "Published run $RUN."


### PR DESCRIPTION
## What

Adds a manual `workflow_dispatch` workflow (**Publish DEV installer for client-download-gateway**) that promotes a launcher-rust PR's dry-run build to the S3 keys `client-download-gateway` serves on `.zone`.

## Why

The gateway serves the launcher installers by reading fixed S3 keys (`zone-downloader-launcher-rust/…`) live on every request. There was no repeatable way to refresh the DEV installers on demand — the current ones date to Dec 2025 and were placed manually. This gives an auditable, one-click path.

## How

- **Inputs:** `pr` (launcher-rust PR number from the build comment) and optional `run` (`run-<num>-<id>` folder; blank resolves to the latest build for that PR by `LastModified`).
- **Copy:** server-side, same-bucket, same-account — from `dry-run-launcher-rust/pr-<N>/run-<id>/` onto the serving keys `Decentraland_installer.exe`, `Decentraland_installer.dmg`, `dcl_launcher.exe`. No deploy needed; the gateway serves the new bytes on the next request.
- **Auth:** reuses the existing `DEV_EXPLORER_TEAM_*` repo secrets (same ones `release.yml` uses for dry-run uploads). No OIDC.
- **Backup:** the `.zone` bucket is unversioned, so the current serving objects are snapshotted to a timestamped `zone-downloader-launcher-rust/_prev/<UTC>/` prefix before overwrite, giving a one-command rollback.

## Notes

- The Windows source is the **unsigned** `Decentraland_installer.exe` by design — the gateway signs it on serve.
- **Trust boundary:** the served bytes are only as trusted as the source PR build. Triggering requires repo-write (`workflow_dispatch`), and the source artifacts require the DEV credentials to have been written — so both the dispatcher and the artifact producer are trusted actors. DEV-only.
- Inputs are validated (`pr` numeric, `run` matches `run-<digits>-<digits>`) to prevent path manipulation of the S3 key prefixes.
- `permissions: contents: read`; no third-party actions used.
