### PR TITLE
fix: prevent cleanup-drafts from failing when no unpublished drafts r…

### DIFF
--- a/.github/workflows/cleanup-s3-artifacts.yml
+++ b/.github/workflows/cleanup-s3-artifacts.yml
@@ -93,8 +93,9 @@ jobs:
           echo "[INFO] Excluding published short SHAs:"
           grep -Ff published_shas.txt draft_shas.txt || true
 
-          # Exclude published SHAs (short)
-          grep -vFf published_shas.txt draft_shas.txt > unpublished_drafts.txt
+          # Exclude published SHAs (short); grep exits 1 when every draft is
+          # published (no unpublished lines), which is not an error here.
+          grep -vFf published_shas.txt draft_shas.txt > unpublished_drafts.txt || true
 
           echo "[INFO] Unpublished draft-release SHAs:"
           cat unpublished_drafts.txt


### PR DESCRIPTION
…emain


## Problem

The `cleanup-drafts` job runs under `set -euo pipefail`. When every draft-release S3 prefix corresponds to a published tag SHA, this line matches zero lines:

    grep -vFf published_shas.txt draft_shas.txt > unpublished_drafts.txt

`grep` exits `1` on no match, which under `set -e` aborts the step — even though "no unpublished drafts" is the correct outcome. The step fails with `Process completed with exit code 1` right after printing the "Excluding published short SHAs" list.

## Fix

Append `|| true`, matching the guard already on the preceding `grep -Ff`:

    grep -vFf published_shas.txt draft_shas.txt > unpublished_drafts.txt || true

Downstream logic already handles an empty `unpublished_drafts.txt` (empty `delete_candidates.txt` → "Nothing to delete").

## Reference

Fixes run [29826767034](https://github.com/decentraland/launcher-rust/actions/runs/29826767034/job/88633848685).
