### PR TITLE
feat: build universal macOS binary for Intel + Apple Silicon

### DIFF
--- a/.github/actions/upload-to-s3/action.yml
+++ b/.github/actions/upload-to-s3/action.yml
@@ -112,6 +112,21 @@ runs:
           mv ./latest.json.tmp ./latest.json
           echo "Updated URLs in latest.json:"
           cat ./latest.json
+
+          # The macOS and Windows jobs each emit a latest.json holding only their own
+          # platform keys and upload to the same S3 path, so the last writer would drop
+          # the other's platforms. Merge with any manifest the sibling job already
+          # uploaded (local keys win on overlap). Safe because target-dir is unique per
+          # commit/run, so an existing manifest there is the same version.
+          S3_LATEST="s3://${{ inputs.s3-bucket }}/${{ inputs.target-dir }}/latest.json"
+          if aws s3 cp --no-progress "$S3_LATEST" ./latest.s3.json 2>/dev/null; then
+            echo "Merging platform keys from existing S3 latest.json"
+            jq -s '(.[0].platforms) as $s3 | .[1] | .platforms = ($s3 + .platforms)' \
+              ./latest.s3.json ./latest.json > ./latest.merged.json
+            mv ./latest.merged.json ./latest.json
+            echo "Merged latest.json:"
+            cat ./latest.json
+          fi
         fi
 
         upload_file "./latest.json" "s3://${{ inputs.s3-bucket }}/${{ inputs.target-dir }}/latest.json"

--- a/.github/actions/upload-to-s3/action.yml
+++ b/.github/actions/upload-to-s3/action.yml
@@ -41,11 +41,19 @@ runs:
         PROJECT_PATH="${{ inputs.project-path }}"
         BUNDLES=$(echo '${{ toJson(matrix.bundles) }}' | jq -r '.[]')
 
+        # macOS universal builds emit under target/universal-apple-darwin/…; everything else under target/release/…
+        if [[ -d "$PROJECT_PATH/target/universal-apple-darwin/release/bundle" ]]; then
+          BUNDLE_BASE="$PROJECT_PATH/target/universal-apple-darwin/release/bundle"
+        else
+          BUNDLE_BASE="$PROJECT_PATH/target/release/bundle"
+        fi
+        echo "Using bundle base: $BUNDLE_BASE"
+
         detected_version=$(find "$PROJECT_PATH" -type f -name 'Decentraland_*_*' | head -n1 | sed -E 's/^.*Decentraland_([0-9]+\.[0-9]+\.[0-9]+)_.*/\1/')
         echo "Detected version: $detected_version"
 
         for bundle in $BUNDLES; do
-          ARTIFACT_DIR="$PROJECT_PATH/target/release/bundle/$bundle"
+          ARTIFACT_DIR="$BUNDLE_BASE/$bundle"
           if [[ -d "$ARTIFACT_DIR" ]]; then
             echo "Renaming artifacts in $ARTIFACT_DIR"
 
@@ -95,10 +103,11 @@ runs:
           echo "Found latest.json at ./latest.json"
 
           jq --arg tar_url "$DOMAIN/$TARGET_PATH/$FILENAME_TAR" \
-             --arg exe_url "$DOMAIN/$TARGET_PATH/$FILENAME_EXE" \
-            '.platforms["darwin-aarch64"].url = $tar_url |
-             .platforms["windows-x86_64"].url = $exe_url' \
-            ./latest.json > ./latest.json.tmp
+             --arg exe_url "$DOMAIN/$TARGET_PATH/$FILENAME_EXE" '
+              (if .platforms | has("darwin-aarch64") then .platforms["darwin-aarch64"].url = $tar_url else . end)
+              | (if .platforms | has("darwin-x86_64")  then .platforms["darwin-x86_64"].url  = $tar_url else . end)
+              | (if .platforms | has("windows-x86_64") then .platforms["windows-x86_64"].url = $exe_url else . end)
+            ' ./latest.json > ./latest.json.tmp
 
           mv ./latest.json.tmp ./latest.json
           echo "Updated URLs in latest.json:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,10 @@ jobs:
         include:
           - os: macos-latest
             bundles: [dmg, macos]
+            args: --target universal-apple-darwin
           - os: windows-latest
             bundles: [nsis]
+            args: ""
 
     runs-on: ${{ matrix.os }}
 
@@ -128,7 +130,7 @@ jobs:
         with:
           toolchain: 1.88.0
           components: clippy,rustfmt
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - run: npm ci
         env:
@@ -254,7 +256,7 @@ jobs:
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true
           prerelease: false
-          args: ${{ secrets.args }}
+          args: ${{ matrix.args }}
           projectPath: ${{ env.PROJECT_PATH }}
 
       - name: Build Dry-Run
@@ -275,7 +277,7 @@ jobs:
           GIT_COMMIT: ${{ github.sha }}
           PR_NUMBER: ${{ inputs.pr-number || 'na' }}
         with:
-          args: ${{ secrets.args }}
+          args: ${{ matrix.args }}
           projectPath: ${{ env.PROJECT_PATH }}
 
       - name: Sign dcl_launcher.exe manually (Win)


### PR DESCRIPTION
## feat: build universal macOS binary for Intel + Apple Silicon

### Problem
The release built only the host architecture (arm64), so Intel Macs had no
installer and could not self-update - the live `latest.json` had no
`darwin-x86_64` key.

### Changes

**`release.yml`**
- Build macOS with `--target universal-apple-darwin` (lipo'd fat binary).
- Fix dead `matrix.platform` -> `matrix.os` so both `aarch64-apple-darwin`
  and `x86_64-apple-darwin` are installed via rustup.
- Replace the empty `secrets.args` with explicit per-platform `matrix.args`
  (Build Release and Build Dry-Run).

**`upload-to-s3/action.yml`**
- Resolve the `universal-apple-darwin` bundle dir so `Decentraland.app.tar.gz`
  is actually uploaded to S3.
- Repoint `darwin-x86_64.url` (which `tauri-action` auto-emits for universal
  builds) to the S3 artifact so Intel installs self-update; `has()`-guarded.
- Merge `latest.json` with any manifest the sibling matrix job already uploaded
  before writing to S3, so concurrent per-platform uploads no longer clobber
  each other (addresses PR review P2).

### Verification before merge
Run a dry-run that dumps `./latest.json` before the jq rewrite to confirm the
published manifest carries both darwin arches and the windows key.

### Notes
- Artifact counts are unchanged (6 release assets, 5 S3 objects); only the macOS
  release-asset arch token changes `aarch64` -> `universal`. S3 names unchanged.
- Residual: a fully race-free manifest would need a single post-matrix writer
  job; not used here because dry-run creates no draft release to merge from.
