### PR TITLE
chore: improve funnel analytic events

### DIFF
--- a/core/src/analytics/event.rs
+++ b/core/src/analytics/event.rs
@@ -18,6 +18,9 @@ pub enum Event {
     FETCH_VERSION_SUCCESS {
         version: String,
     },
+    FETCH_VERSION_ERROR {
+        error: String,
+    },
     DOWNLOAD_VERSION {
         version: String,
     },
@@ -100,6 +103,7 @@ impl Display for Event {
                 Event::LAUNCHER_CLOSE { .. } => "Launcher Close",
                 Event::FETCH_VERSION_START => "Fetch Version Start",
                 Event::FETCH_VERSION_SUCCESS { .. } => "Fetch Version Success",
+                Event::FETCH_VERSION_ERROR { .. } => "Fetch Version Error",
                 Event::DOWNLOAD_VERSION { .. } => "Download Version",
                 Event::DOWNLOAD_VERSION_PROGRESS { .. } => "Download Version Progress",
                 Event::DOWNLOAD_VERSION_SUCCESS { .. } => "Download Version Success",

--- a/core/src/analytics/event.rs
+++ b/core/src/analytics/event.rs
@@ -14,6 +14,10 @@ pub enum Event {
     LAUNCHER_CLOSE {
         version: String,
     },
+    FETCH_VERSION_START,
+    FETCH_VERSION_SUCCESS {
+        version: String,
+    },
     DOWNLOAD_VERSION {
         version: String,
     },
@@ -88,6 +92,8 @@ impl Display for Event {
             match self {
                 Event::LAUNCHER_OPEN { .. } => "Launcher Open",
                 Event::LAUNCHER_CLOSE { .. } => "Launcher Close",
+                Event::FETCH_VERSION_START => "Fetch Version Start",
+                Event::FETCH_VERSION_SUCCESS { .. } => "Fetch Version Success",
                 Event::DOWNLOAD_VERSION { .. } => "Download Version",
                 Event::DOWNLOAD_VERSION_PROGRESS { .. } => "Download Version Progress",
                 Event::DOWNLOAD_VERSION_SUCCESS { .. } => "Download Version Success",

--- a/core/src/analytics/event.rs
+++ b/core/src/analytics/event.rs
@@ -36,6 +36,9 @@ pub enum Event {
     DOWNLOAD_VERSION_CANCELLED {
         version: String,
     },
+    DOWNLOAD_VERSION_SKIPPED {
+        version: String,
+    },
     INSTALL_VERSION_START {
         version: String,
     },
@@ -45,6 +48,9 @@ pub enum Event {
     INSTALL_VERSION_ERROR {
         version: Option<String>,
         error: String,
+    },
+    INSTALL_VERSION_SKIPPED {
+        version: String,
     },
     LAUNCH_CLIENT_START {
         version: String,
@@ -99,9 +105,11 @@ impl Display for Event {
                 Event::DOWNLOAD_VERSION_SUCCESS { .. } => "Download Version Success",
                 Event::DOWNLOAD_VERSION_ERROR { .. } => "Download Version Error",
                 Event::DOWNLOAD_VERSION_CANCELLED { .. } => "Download Version Cancelled",
+                Event::DOWNLOAD_VERSION_SKIPPED { .. } => "Download Version Skipped",
                 Event::INSTALL_VERSION_START { .. } => "Install Version Start",
                 Event::INSTALL_VERSION_SUCCESS { .. } => "Install Version Success",
                 Event::INSTALL_VERSION_ERROR { .. } => "Install Version Error",
+                Event::INSTALL_VERSION_SKIPPED { .. } => "Install Version Skipped",
                 Event::LAUNCH_CLIENT_START { .. } => "Launch Client Start",
                 Event::LAUNCH_CLIENT_SUCCESS { .. } => "Launch Client Success",
                 Event::LAUNCH_CLIENT_ERROR { .. } => "Launch Client Error",

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -111,60 +111,94 @@ impl LaunchFlow {
         channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
     ) -> std::result::Result<(), FlowError> {
+        let handled_by_passthrough = self.prepare_with_retries(channel, state.clone()).await?;
+        if handled_by_passthrough {
+            return std::result::Result::Ok(());
+        }
+
+        self.launch_once(channel, state).await
+    }
+
+    async fn prepare_with_retries<T: EventChannel>(
+        &self,
+        channel: &T,
+        state: Arc<Mutex<LaunchFlowState>>,
+    ) -> std::result::Result<bool, FlowError> {
         const SILENT_ATTEMPTS_COUNT: u8 = 3;
 
         let mut last_error: Option<AttemptError> = None;
 
         for attempt in 1..=SILENT_ATTEMPTS_COUNT {
-            let result = self.launch_internal(channel, state.clone()).await;
-
-            if let Err(e) = result {
-                log::error!(
-                    "Error during the flow. Attempt: {}, Cause {} {:#?}",
-                    attempt,
-                    e,
-                    e
-                );
-                let code = e.code();
-                let e = AttemptError { error: e, attempt };
-
-                sentry::with_scope(
-                    |scope| {
-                        scope.set_tag("error_code", code);
-                        scope.set_fingerprint(Some(&[code]));
-                    },
-                    || {
-                        sentry::capture_error(&e);
-                    },
-                );
-                self.analytics
-                    .lock()
-                    .await
-                    .track_and_flush_silent((&e).into())
-                    .await;
-
-                last_error = Some(e);
-                continue;
+            match self.prepare_internal(channel, state.clone()).await {
+                std::result::Result::Ok(handled_by_passthrough) => {
+                    return std::result::Result::Ok(handled_by_passthrough);
+                }
+                std::result::Result::Err(e) => {
+                    last_error = Some(self.report_attempt_error(e, attempt).await);
+                }
             }
-
-            return std::result::Result::Ok(());
         }
 
-        if let Some(e) = last_error {
-            let error = FlowError {
-                user_message: e.error.user_message().to_owned(),
-            };
-            std::result::Result::Err(error)
-        } else {
-            std::result::Result::Ok(())
-        }
+        std::result::Result::Err(FlowError {
+            user_message: last_error
+                .map(|e| e.error.user_message().to_owned())
+                .unwrap_or_default(),
+        })
     }
 
-    async fn launch_internal<T: EventChannel>(
+    async fn launch_once<T: EventChannel>(
         &self,
         channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
-    ) -> StepResult {
+    ) -> std::result::Result<(), FlowError> {
+        match self
+            .app_launch_step
+            .execute_if_needed(channel, state, "launch")
+            .await
+        {
+            std::result::Result::Ok(_) => std::result::Result::Ok(()),
+            std::result::Result::Err(e) => {
+                let e = self.report_attempt_error(e, 1).await;
+                std::result::Result::Err(FlowError {
+                    user_message: e.error.user_message().to_owned(),
+                })
+            }
+        }
+    }
+
+    async fn report_attempt_error(&self, error: StepError, attempt: u8) -> AttemptError {
+        log::error!(
+            "Error during the flow. Attempt: {}, Cause {} {:#?}",
+            attempt,
+            error,
+            error
+        );
+        let code = error.code();
+        let attempt_error = AttemptError { error, attempt };
+
+        sentry::with_scope(
+            |scope| {
+                scope.set_tag("error_code", code);
+                scope.set_fingerprint(Some(&[code]));
+            },
+            || {
+                sentry::capture_error(&attempt_error);
+            },
+        );
+        self.analytics
+            .lock()
+            .await
+            .track_and_flush_silent((&attempt_error).into())
+            .await;
+
+        attempt_error
+    }
+
+    async fn prepare_internal<T: EventChannel>(
+        &self,
+        channel: &T,
+        state: Arc<Mutex<LaunchFlowState>>,
+    ) -> StepResultTyped<bool> {
         let handled_by_passthrough = self
             .deeplink_passthrough_step
             .execute_if_needed(channel, state.clone(), "deeplink_passthrough")
@@ -176,7 +210,7 @@ impl LaunchFlow {
             info!(
                 "Deeplink handled by passthrough (an Explorer instance is already running); skipping further steps"
             );
-            return StepResult::Ok(());
+            return StepResultTyped::Ok(true);
         }
 
         self.fetch_step
@@ -188,10 +222,8 @@ impl LaunchFlow {
         self.install_step
             .execute_if_needed(channel, state.clone(), "install")
             .await?;
-        self.app_launch_step
-            .execute_if_needed(channel, state.clone(), "launch")
-            .await?;
-        StepResult::Ok(())
+
+        StepResultTyped::Ok(false)
     }
 }
 

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -28,6 +28,8 @@ trait WorkflowStep<TState, TOutput> {
         state: Arc<Mutex<TState>>,
     ) -> StepResultTyped<TOutput>;
 
+    async fn on_skipped(&self, _state: Arc<Mutex<TState>>) {}
+
     async fn execute_if_needed<T: EventChannel>(
         &self,
         channel: &T,
@@ -37,6 +39,7 @@ trait WorkflowStep<TState, TOutput> {
         let complete = self.is_complete(state.clone()).await?;
         if complete {
             info!("Step {} is already complete", label);
+            self.on_skipped(state).await;
             return StepResultTyped::Ok(None);
         }
 
@@ -291,6 +294,22 @@ impl WorkflowStep<LaunchFlowState, ()> for DownloadStep {
         }
     }
 
+    async fn on_skipped(&self, state: Arc<Mutex<LaunchFlowState>>) {
+        let version = state
+            .lock()
+            .await
+            .latest_release
+            .as_ref()
+            .map(|r| r.version.clone());
+        if let Some(version) = version {
+            self.analytics
+                .lock()
+                .await
+                .track_and_flush_silent(Event::DOWNLOAD_VERSION_SKIPPED { version })
+                .await;
+        }
+    }
+
     fn start_label(&self) -> Result<Status> {
         let mode = Self::mode();
         let status = Status::State {
@@ -423,6 +442,22 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
 
         Ok(guard.recent_download.is_none()
             && installs::explorer_latest_version_path().exists())
+    }
+
+    async fn on_skipped(&self, state: Arc<Mutex<LaunchFlowState>>) {
+        let version = state
+            .lock()
+            .await
+            .latest_release
+            .as_ref()
+            .map(|r| r.version.clone());
+        if let Some(version) = version {
+            self.analytics
+                .lock()
+                .await
+                .track_and_flush_silent(Event::INSTALL_VERSION_SKIPPED { version })
+                .await;
+        }
     }
 
     fn start_label(&self) -> Result<Status> {

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -257,7 +257,17 @@ impl WorkflowStep<LaunchFlowState, ()> for FetchStep {
             .track_and_flush_silent(Event::FETCH_VERSION_START)
             .await;
 
-        let latest_release = crate::s3::get_latest_explorer_release().await?;
+        let fetch_result = crate::s3::get_latest_explorer_release().await;
+        if let Err(e) = &fetch_result {
+            self.analytics
+                .lock()
+                .await
+                .track_and_flush_silent(Event::FETCH_VERSION_ERROR {
+                    error: e.to_string(),
+                })
+                .await;
+        }
+        let latest_release = fetch_result?;
         let version = latest_release.version.clone();
         state.lock().await.latest_release = Some(latest_release);
 

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -28,7 +28,9 @@ trait WorkflowStep<TState, TOutput> {
         state: Arc<Mutex<TState>>,
     ) -> StepResultTyped<TOutput>;
 
-    async fn on_skipped(&self, _state: Arc<Mutex<TState>>) {}
+    fn on_skipped(&self, _state: Arc<Mutex<TState>>) -> impl std::future::Future<Output = ()> {
+        std::future::ready(())
+    }
 
     async fn execute_if_needed<T: EventChannel>(
         &self,

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -160,9 +160,19 @@ impl LaunchFlow {
         {
             std::result::Result::Ok(_) => std::result::Result::Ok(()),
             std::result::Result::Err(e) => {
-                let e = self.report_attempt_error(e, 1).await;
+                log::error!("Error launching Explorer. Cause {} {:#?}", e, e);
+                let code = e.code();
+                sentry::with_scope(
+                    |scope| {
+                        scope.set_tag("error_code", code);
+                        scope.set_fingerprint(Some(&[code]));
+                    },
+                    || {
+                        sentry::capture_error(&e);
+                    },
+                );
                 std::result::Result::Err(FlowError {
-                    user_message: e.error.user_message().to_owned(),
+                    user_message: e.user_message().to_owned(),
                 })
             }
         }

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -85,7 +85,9 @@ impl LaunchFlow {
         };
 
         Self {
-            fetch_step: FetchStep {},
+            fetch_step: FetchStep {
+                analytics: analytics.clone(),
+            },
             download_step: DownloadStep {
                 analytics: analytics.clone(),
             },
@@ -190,7 +192,9 @@ impl LaunchFlow {
     }
 }
 
-struct FetchStep {}
+struct FetchStep {
+    analytics: Arc<Mutex<Analytics>>,
+}
 
 impl WorkflowStep<LaunchFlowState, ()> for FetchStep {
     async fn is_complete(&self, _state: Arc<Mutex<LaunchFlowState>>) -> Result<bool> {
@@ -210,9 +214,22 @@ impl WorkflowStep<LaunchFlowState, ()> for FetchStep {
         _channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
     ) -> StepResult {
-        let mut guard = state.lock().await;
+        self.analytics
+            .lock()
+            .await
+            .track_and_flush_silent(Event::FETCH_VERSION_START)
+            .await;
+
         let latest_release = crate::s3::get_latest_explorer_release().await?;
-        guard.latest_release = Some(latest_release);
+        let version = latest_release.version.clone();
+        state.lock().await.latest_release = Some(latest_release);
+
+        self.analytics
+            .lock()
+            .await
+            .track_and_flush_silent(Event::FETCH_VERSION_SUCCESS { version })
+            .await;
+
         StepResult::Ok(())
     }
 }

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -685,10 +685,10 @@ impl InstallsHub {
             };
 
             if tokio::time::timeout(POLL_TIMEOUT, poll).await.is_err() {
-                log::error!(
-                    "Timed out waiting for Explorer process under {} to appear",
+                return Err(anyhow!(
+                    "Explorer process under {} did not start",
                     explorer_launch_path.display()
-                );
+                ));
             }
         }
 


### PR DESCRIPTION
## Improve launch funnel analytics

**Why:** We couldn't cleanly measure the user journey from launcher start to Explorer open, or tell real drop-offs apart from normal skips.

**What changed:**

- **Measure the version-check step.** The initial "fetch latest version" step now emits start/success events. It was previously untracked, so the top of the funnel was invisible.
- **Tell "already up to date" apart from "dropped off."** Returning users on the latest version skip the download/install steps. We now emit explicit *skipped* events so they're no longer miscounted as download failures.
- **Only count a launch as successful when the Explorer actually opens.** Before, a launch counted as successful the moment the process was spawned — on macOS this could report success even when the Explorer never came up. It now reports an error in that case. A failed launch also surfaces to the user instead of silently retrying (which on macOS risked opening duplicate windows).

**Result:** the funnel from launcher open → Explorer running is now measurable end to end, with skips, drop-offs, and genuine failures each distinguishable.

## Test instructions

Check the Explorer launches correctly on macOS & Windows.
