### PR TITLE
fix: prevent sentry duplicates and improve fingerprint codes

### DIFF
--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -13,7 +13,7 @@ use crate::{
         AppEnvironment, Args, ARG_BRIDGE_ONLY, ARG_LOCAL_SCENE, ARG_MULTI_INSTANCE,
         ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE,
     },
-    errors::{StepError, StepResult},
+    errors::{DCLError, DCLErrorResult},
     installs::deeplink_bridge_path,
     protocols::DeepLink,
     types::{Status, Step},
@@ -120,7 +120,7 @@ pub fn should_use_deeplink_bridge_for(deeplink: &DeepLink, any_is_running: bool)
 pub async fn execute_passthrough<T: EventChannel>(
     channel: &T,
     deeplink: &DeepLink,
-) -> StepResult {
+) -> DCLErrorResult {
     const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
 
     channel.send(Status::State {
@@ -151,7 +151,7 @@ pub async fn execute_passthrough<T: EventChannel>(
             // to completion lets that arm remove the bridge file before we report the timeout.
             token.cancel();
             let _ = (&mut wait).await;
-            return StepResult::Err(StepError::E3001_OPEN_DEEPLINK_TIMEOUT);
+            return DCLErrorResult::Err(DCLError::E3001_OPEN_DEEPLINK_TIMEOUT);
         }
     };
 
@@ -163,9 +163,9 @@ pub async fn execute_passthrough<T: EventChannel>(
                 #[cfg(target_os = "macos")]
                 try_bring_explorer_to_front();
             }
-            StepResult::Ok(())
+            DCLErrorResult::Ok(())
         }
-        PlaceDeeplinkResult::Err(error) => StepResult::Err(error.into()),
+        PlaceDeeplinkResult::Err(error) => DCLErrorResult::Err(error.into()),
     }
 }
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -77,7 +77,7 @@ pub enum DCLError {
     E1006_FILE_DELETE_FAILED {
         file_path: String,
         #[source]
-        inner_error: anyhow::Error,
+        source: std::io::Error,
     },
     E1007_FILE_CREATE_FAILED {
         file_path: String,

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -258,7 +258,7 @@ impl StepError {
                 "Decentraland isn't installed correctly. Please close the launcher and open it again to reinstall it."
             }
             Self::E3010_EXPLORER_LAUNCH_FAILED { .. } => {
-                "We couldn't start Decentraland. Please close the launcher and open it again. If the problem continues, try running it as administrator."
+                "We couldn't start Decentraland. Please close the launcher and open it again."
             }
             Self::E3011_EXPLORER_PROCESS_NOT_STARTED { .. } => {
                 "Decentraland didn't start. Please make sure your antivirus isn't blocking it and try again."

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -127,6 +127,26 @@ pub enum StepError {
     E3008_EXPLORER_ALREADY_RUNNING {
         processes: Vec<String>,
     },
+    E3009_EXPLORER_NOT_INSTALLED {
+        expected_path: String,
+        version: Option<String>,
+    },
+    E3010_EXPLORER_LAUNCH_FAILED {
+        path: String,
+        #[source]
+        inner_error: anyhow::Error,
+    },
+    E3011_EXPLORER_PROCESS_NOT_STARTED {
+        path: String,
+    },
+    E3012_EXPLORER_EXITED_ON_LAUNCH {
+        exit_code: String,
+    },
+    E3013_EXPLORER_BINARY_ACCESS_FAILED {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 impl StepError {
@@ -233,6 +253,21 @@ impl StepError {
             }
             Self::E3008_EXPLORER_ALREADY_RUNNING { .. } => {
                 "Decentraland is already running and is blocking the update. Please close it and try again."
+            }
+            Self::E3009_EXPLORER_NOT_INSTALLED { .. } => {
+                "Decentraland isn't installed correctly. Please close the launcher and open it again to reinstall it."
+            }
+            Self::E3010_EXPLORER_LAUNCH_FAILED { .. } => {
+                "We couldn't start Decentraland. Please close the launcher and open it again. If the problem continues, try running it as administrator."
+            }
+            Self::E3011_EXPLORER_PROCESS_NOT_STARTED { .. } => {
+                "Decentraland didn't start. Please make sure your antivirus isn't blocking it and try again."
+            }
+            Self::E3012_EXPLORER_EXITED_ON_LAUNCH { .. } => {
+                "Decentraland closed unexpectedly right after starting. Please try again, and make sure your graphics drivers are up to date."
+            }
+            Self::E3013_EXPLORER_BINARY_ACCESS_FAILED { .. } => {
+                "We couldn't access the Decentraland files. If Decentraland is open, please close it and try again."
             }
         }
     }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::HashMap, fmt::Display, path::Path};
 use strum::IntoStaticStr;
 use thiserror::Error;
 
@@ -150,6 +150,35 @@ pub enum DCLError {
 }
 
 impl DCLError {
+    pub fn from_cleanup(path: &Path, source: std::io::Error) -> Self {
+        Self::E3005_STALE_BUILD_CLEANUP_FAILED {
+            path: path.to_string_lossy().into_owned(),
+            source,
+        }
+    }
+
+    pub fn from_rename_back(path: &Path, source: std::io::Error) -> Self {
+        Self::E3006_RENAME_BACK_FAILED {
+            path: path.to_string_lossy().into_owned(),
+            source,
+        }
+    }
+
+    pub fn from_launch_failure(path: &Path, inner_error: anyhow::Error) -> Self {
+        Self::E3010_EXPLORER_LAUNCH_FAILED {
+            path: path.to_string_lossy().into_owned(),
+            inner_error,
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn from_binary_access(path: &Path, source: std::io::Error) -> Self {
+        Self::E3013_EXPLORER_BINARY_ACCESS_FAILED {
+            path: path.to_string_lossy().into_owned(),
+            source,
+        }
+    }
+
     /// Stable identifier for Sentry grouping. Must not include any variable
     /// data (paths, OS messages) — only the variant name. Sentry fingerprints
     /// off this so all occurrences of the same failure cluster into one issue.

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -24,7 +24,7 @@ impl From<&FlowError> for Status {
 #[derive(Error, Debug)]
 pub struct AttemptError {
     #[source]
-    pub(crate) error: StepError,
+    pub(crate) error: DCLError,
     pub(crate) attempt: u8,
 }
 
@@ -38,19 +38,19 @@ impl Display for AttemptError {
     }
 }
 
-pub type StepResult = std::result::Result<(), StepError>;
+pub type DCLErrorResult = std::result::Result<(), DCLError>;
 
-pub type StepResultTyped<T> = std::result::Result<T, StepError>;
+pub type DCLErrorTyped<T> = std::result::Result<T, DCLError>;
 
-impl<T> From<StepError> for StepResultTyped<T> {
-    fn from(value: StepError) -> Self {
+impl<T> From<DCLError> for DCLErrorTyped<T> {
+    fn from(value: DCLError) -> Self {
         Self::Err(value)
     }
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Error, Debug, IntoStaticStr)]
-pub enum StepError {
+pub enum DCLError {
     E0000_GENERIC_ERROR {
         #[source]
         error: anyhow::Error,
@@ -149,7 +149,7 @@ pub enum StepError {
     },
 }
 
-impl StepError {
+impl DCLError {
     /// Stable identifier for Sentry grouping. Must not include any variable
     /// data (paths, OS messages) — only the variant name. Sentry fingerprints
     /// off this so all occurrences of the same failure cluster into one issue.
@@ -273,13 +273,13 @@ impl StepError {
     }
 }
 
-impl Display for StepError {
+impl Display for DCLError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.user_message())
     }
 }
 
-impl From<anyhow::Error> for StepError {
+impl From<anyhow::Error> for DCLError {
     fn from(value: anyhow::Error) -> Self {
         Self::E0000_GENERIC_ERROR {
             error: value,
@@ -288,7 +288,7 @@ impl From<anyhow::Error> for StepError {
     }
 }
 
-impl From<std::io::Error> for StepError {
+impl From<std::io::Error> for DCLError {
     fn from(value: std::io::Error) -> Self {
         use std::io::ErrorKind::*;
 
@@ -311,7 +311,7 @@ impl From<std::io::Error> for StepError {
     }
 }
 
-impl From<zip::result::ZipError> for StepError {
+impl From<zip::result::ZipError> for DCLError {
     fn from(value: zip::result::ZipError) -> Self {
         match value {
             zip::result::ZipError::Io(io_err) => Self::from(io_err),
@@ -335,7 +335,7 @@ impl From<zip::result::ZipError> for StepError {
     }
 }
 
-impl From<DownloadFileError> for StepError {
+impl From<DownloadFileError> for DCLError {
     fn from(value: DownloadFileError) -> Self {
         use DownloadFileError::*;
         match value {
@@ -355,7 +355,7 @@ impl From<DownloadFileError> for StepError {
     }
 }
 
-impl From<reqwest::Error> for StepError {
+impl From<reqwest::Error> for DCLError {
     fn from(value: reqwest::Error) -> Self {
         let url: Option<String> = value.url().map(|e| e.as_str().to_owned());
         Self::E2001_DOWNLOAD_FAILED { url, error: value }

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -1,13 +1,13 @@
 use crate::channel::EventChannel;
 use crate::deeplink_bridge::{execute_passthrough, should_use_deeplink_bridge_for};
-use crate::errors::{AttemptError, StepError, StepResultTyped};
+use crate::errors::{AttemptError, DCLError, DCLErrorTyped};
 use crate::instances::RunningInstances;
 use crate::logs::LogDestination;
 use crate::protocols::{DeepLink, Protocol};
 use crate::{
     analytics::{Analytics, event::Event},
     environment::AppEnvironment,
-    errors::{FlowError, StepResult},
+    errors::{FlowError, DCLErrorResult},
     installs::{self, InstallsHub},
     s3::{self, ReleaseResponse},
     types::{BuildType, Status, Step},
@@ -27,7 +27,7 @@ trait WorkflowStep<TState, TOutput> {
         &self,
         channel: &T,
         state: Arc<Mutex<TState>>,
-    ) -> StepResultTyped<TOutput>;
+    ) -> DCLErrorTyped<TOutput>;
 
     fn on_skipped(&self, _state: Arc<Mutex<TState>>) -> impl std::future::Future<Output = ()> {
         std::future::ready(())
@@ -38,12 +38,12 @@ trait WorkflowStep<TState, TOutput> {
         channel: &T,
         state: Arc<Mutex<TState>>,
         label: &str,
-    ) -> StepResultTyped<Option<TOutput>> {
+    ) -> DCLErrorTyped<Option<TOutput>> {
         let complete = self.is_complete(state.clone()).await?;
         if complete {
             info!("Step {} is already complete", label);
             self.on_skipped(state).await;
-            return StepResultTyped::Ok(None);
+            return DCLErrorTyped::Ok(None);
         }
 
         let status = self.start_label()?;
@@ -52,7 +52,7 @@ trait WorkflowStep<TState, TOutput> {
         info!("Step {} is started", label);
         let result = self.execute(channel, state).await?;
         info!("Step {} is finished", label);
-        StepResultTyped::Ok(Some(result))
+        DCLErrorTyped::Ok(Some(result))
     }
 }
 
@@ -184,7 +184,7 @@ impl LaunchFlow {
         }
     }
 
-    async fn report_attempt_error(&self, error: StepError, attempt: u8) -> AttemptError {
+    async fn report_attempt_error(&self, error: DCLError, attempt: u8) -> AttemptError {
         log::error!(
             target: LogDestination::File.as_target(),
             "Error during the flow. Attempt: {}, Cause {} {:#?}",
@@ -218,7 +218,7 @@ impl LaunchFlow {
         &self,
         channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
-    ) -> StepResultTyped<bool> {
+    ) -> DCLErrorTyped<bool> {
         let handled_by_passthrough = self
             .deeplink_passthrough_step
             .execute_if_needed(channel, state.clone(), "deeplink_passthrough")
@@ -230,7 +230,7 @@ impl LaunchFlow {
             info!(
                 "Deeplink handled by passthrough (an Explorer instance is already running); skipping further steps"
             );
-            return StepResultTyped::Ok(true);
+            return DCLErrorTyped::Ok(true);
         }
 
         self.fetch_step
@@ -243,7 +243,7 @@ impl LaunchFlow {
             .execute_if_needed(channel, state.clone(), "install")
             .await?;
 
-        StepResultTyped::Ok(false)
+        DCLErrorTyped::Ok(false)
     }
 }
 
@@ -268,7 +268,7 @@ impl WorkflowStep<LaunchFlowState, ()> for FetchStep {
         &self,
         _channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
-    ) -> StepResult {
+    ) -> DCLErrorResult {
         self.analytics
             .lock()
             .await
@@ -295,7 +295,7 @@ impl WorkflowStep<LaunchFlowState, ()> for FetchStep {
             .track_and_flush_silent(Event::FETCH_VERSION_SUCCESS { version })
             .await;
 
-        StepResult::Ok(())
+        DCLErrorResult::Ok(())
     }
 }
 
@@ -387,7 +387,7 @@ impl WorkflowStep<LaunchFlowState, ()> for DownloadStep {
         &self,
         channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
-    ) -> StepResult {
+    ) -> DCLErrorResult {
         let mode = Self::mode();
 
         let mut guard = state.lock().await;
@@ -447,9 +447,9 @@ impl WorkflowStep<LaunchFlowState, ()> for DownloadStep {
                     downloaded_path: target_path,
                 });
 
-                StepResult::Ok(())
+                DCLErrorResult::Ok(())
             }
-            None => StepResult::Err(anyhow!("Latest release is not fetched").into()),
+            None => DCLErrorResult::Err(anyhow!("Latest release is not fetched").into()),
         }
     }
 }
@@ -460,7 +460,7 @@ struct InstallStep {
 }
 
 impl InstallStep {
-    async fn execute_internal(&self, recent_download: RecentDownload) -> StepResult {
+    async fn execute_internal(&self, recent_download: RecentDownload) -> DCLErrorResult {
         self.check_explorer_not_running().await?;
         installs::install_explorer(
             &recent_download.version,
@@ -469,7 +469,7 @@ impl InstallStep {
         .and_then(|()| installs::rename_explorer_to_latest())
     }
 
-    async fn check_explorer_not_running(&self) -> StepResult {
+    async fn check_explorer_not_running(&self) -> DCLErrorResult {
         let running = self
             .running_instances
             .lock()
@@ -477,14 +477,14 @@ impl InstallStep {
             .explorer_processes_by_path();
         if running.is_empty() {
             // `Ok`/`Err` are shadowed by `anyhow::Ok` (imported at the top),
-            // so qualify with `StepResult` to stay on `StepError`.
-            return StepResult::Ok(());
+            // so qualify with `DCLErrorResult` to stay on `DCLError`.
+            return DCLErrorResult::Ok(());
         }
         log::warn!(
             "Explorer is still running; refusing to install. Blocking processes: {:?}",
             running
         );
-        StepResult::Err(StepError::E3008_EXPLORER_ALREADY_RUNNING { processes: running })
+        DCLErrorResult::Err(DCLError::E3008_EXPLORER_ALREADY_RUNNING { processes: running })
     }
 
     async fn recent_download_and_update_state(
@@ -534,7 +534,7 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
         &self,
         _channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
-    ) -> StepResult {
+    ) -> DCLErrorResult {
         let recent_download = Self::recent_download_and_update_state(state).await;
 
         if let Some(download) = recent_download {
@@ -566,7 +566,7 @@ impl WorkflowStep<LaunchFlowState, ()> for InstallStep {
             return result;
         }
 
-        StepResult::Ok(())
+        DCLErrorResult::Ok(())
     }
 }
 
@@ -611,19 +611,19 @@ impl WorkflowStep<LaunchFlowState, bool> for DeeplinkPassthroughStep {
         &self,
         channel: &T,
         _: Arc<Mutex<LaunchFlowState>>,
-    ) -> StepResultTyped<bool> {
+    ) -> DCLErrorTyped<bool> {
         let Some(deeplink) = Protocol::value() else {
-            return StepResultTyped::Ok(false);
+            return DCLErrorTyped::Ok(false);
         };
 
         // Re-check the bridge policy against this snapshot: an open_url event may have
         // reassigned the protocol since `is_complete`, so decide and act on one value.
         if !self.should_use_deeplink_bridge_for(&deeplink).await? {
-            return StepResultTyped::Ok(false);
+            return DCLErrorTyped::Ok(false);
         }
 
         execute_passthrough(channel, &deeplink).await?;
-        StepResultTyped::Ok(true)
+        DCLErrorTyped::Ok(true)
     }
 }
 
@@ -656,7 +656,7 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
         &self,
         channel: &T,
         _state: Arc<Mutex<LaunchFlowState>>,
-    ) -> StepResult {
+    ) -> DCLErrorResult {
         match Protocol::value() {
             Some(deeplink) => {
                 if self.should_use_deeplink_bridge_for(&deeplink).await? {
@@ -667,7 +667,7 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
                         .await
                         .launch_explorer(Some(deeplink), None)
                         .await?;
-                    StepResult::Ok(())
+                    DCLErrorResult::Ok(())
                 }
             }
             None => {
@@ -677,7 +677,7 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
                     .await
                     .launch_explorer(None, None)
                     .await?;
-                StepResult::Ok(())
+                DCLErrorResult::Ok(())
             }
         }
     }

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -2,7 +2,7 @@ use crate::channel::EventChannel;
 use crate::deeplink_bridge::{execute_passthrough, should_use_deeplink_bridge_for};
 use crate::errors::{AttemptError, StepError, StepResultTyped};
 use crate::instances::RunningInstances;
-use crate::logs::LOG_TO_FILE;
+use crate::logs::LogDestination;
 use crate::protocols::{DeepLink, Protocol};
 use crate::{
     analytics::{Analytics, event::Event},
@@ -162,7 +162,7 @@ impl LaunchFlow {
             std::result::Result::Ok(_) => std::result::Result::Ok(()),
             std::result::Result::Err(e) => {
                 log::error!(
-                    target: LOG_TO_FILE,
+                    target: LogDestination::File.as_target(),
                     "Error launching Explorer. Cause {} {:#?}",
                     e,
                     e
@@ -186,7 +186,7 @@ impl LaunchFlow {
 
     async fn report_attempt_error(&self, error: StepError, attempt: u8) -> AttemptError {
         log::error!(
-            target: LOG_TO_FILE,
+            target: LogDestination::File.as_target(),
             "Error during the flow. Attempt: {}, Cause {} {:#?}",
             attempt,
             error,

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -2,6 +2,7 @@ use crate::channel::EventChannel;
 use crate::deeplink_bridge::{execute_passthrough, should_use_deeplink_bridge_for};
 use crate::errors::{AttemptError, StepError, StepResultTyped};
 use crate::instances::RunningInstances;
+use crate::logs::LOG_TO_FILE;
 use crate::protocols::{DeepLink, Protocol};
 use crate::{
     analytics::{Analytics, event::Event},
@@ -160,7 +161,12 @@ impl LaunchFlow {
         {
             std::result::Result::Ok(_) => std::result::Result::Ok(()),
             std::result::Result::Err(e) => {
-                log::error!("Error launching Explorer. Cause {} {:#?}", e, e);
+                log::error!(
+                    target: LOG_TO_FILE,
+                    "Error launching Explorer. Cause {} {:#?}",
+                    e,
+                    e
+                );
                 let code = e.code();
                 sentry::with_scope(
                     |scope| {
@@ -180,11 +186,13 @@ impl LaunchFlow {
 
     async fn report_attempt_error(&self, error: StepError, attempt: u8) -> AttemptError {
         log::error!(
+            target: LOG_TO_FILE,
             "Error during the flow. Attempt: {}, Cause {} {:#?}",
             attempt,
             error,
             error
         );
+        
         let code = error.code();
         let attempt_error = AttemptError { error, attempt };
 

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -3,7 +3,7 @@ use crate::analytics::event::Event;
 use crate::config;
 use crate::download_origin_metadata::startup_location_storage::StartupDeeplinkStorage;
 use crate::environment::AppEnvironment;
-use crate::errors::{StepError, StepResult};
+use crate::errors::{StepError, StepResult, StepResultTyped};
 use crate::instances::RunningInstances;
 #[cfg(target_os = "windows")]
 use crate::processes::CommandExtDetached;
@@ -165,14 +165,14 @@ fn get_version_data_or_empty() -> Map<String, Value> {
     })
 }
 
-fn get_latest_version(version_data: &Map<String, Value>) -> Result<&str> {
+fn get_latest_version(version_data: &Map<String, Value>) -> StepResultTyped<&str> {
     version_data
         .get("version")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!(StepError::E3003_CANT_GET_VERSION.user_message()))
+        .ok_or(StepError::E3003_CANT_GET_VERSION)
 }
 
-pub(crate) fn get_explorer_launch_path(version: Option<&str>) -> Result<PathBuf> {
+pub(crate) fn get_explorer_launch_path(version: Option<&str>) -> StepResultTyped<PathBuf> {
     let base_path = match version {
         None => explorer_latest_version_path(),
         Some("dev") => explorer_dev_version_path(),
@@ -296,17 +296,27 @@ fn remove_version_if_exists(version: &EntryVersion) {
     }
 }
 
-fn cleanup_versions(current_version: &EntryVersion) -> Result<()> {
+fn cleanup_versions(current_version: &EntryVersion) -> StepResult {
     const KEEP_VERSIONS_FOR_ROLLBACK_AMOUNT: usize = 2;
 
-    let entries = fs::read_dir(explorer_path()).context("Cannot read entries in the app dir")?;
+    let explorer_path = explorer_path();
+    let entries =
+        fs::read_dir(&explorer_path).map_err(|e| as_stale_cleanup_err(&explorer_path, e))?;
 
     let mut installations: Vec<EntryVersion> = Vec::new();
 
     for entry in entries {
         let Ok(entry) = entry else { continue };
         let file_name = entry.file_name();
-        let entry_name = file_name.to_str().context("no file name on entry")?;
+        let entry_name = file_name.to_str().ok_or_else(|| {
+            as_stale_cleanup_err(
+                &entry.path(),
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "entry name is not valid UTF-8",
+                ),
+            )
+        })?;
 
         if let Some(version) = EntryVersion::from_str(entry_name) {
             installations.push(version);
@@ -379,6 +389,13 @@ pub fn target_download_path() -> PathBuf {
 
 fn as_rename_back_err(path: &Path, source: std::io::Error) -> StepError {
     StepError::E3006_RENAME_BACK_FAILED {
+        path: path.to_string_lossy().into_owned(),
+        source,
+    }
+}
+
+fn as_stale_cleanup_err(path: &Path, source: std::io::Error) -> StepError {
+    StepError::E3005_STALE_BUILD_CLEANUP_FAILED {
         path: path.to_string_lossy().into_owned(),
         source,
     }
@@ -495,8 +512,11 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         .map_err(|source| StepError::E3007_VERSION_DATA_WRITE_FAILED { source })?;
 
     // Remove the downloaded file
-    fs::remove_file(file_path)?;
-    cleanup_versions(&current_version).context("Cannot clean up the old versions")?;
+    fs::remove_file(&file_path).map_err(|e| StepError::E1006_FILE_DELETE_FAILED {
+        file_path: file_path.to_string_lossy().into_owned(),
+        inner_error: e.into(),
+    })?;
+    cleanup_versions(&current_version)?;
 
     Ok(())
 }
@@ -506,9 +526,7 @@ pub fn rename_explorer_to_latest() -> StepResult {
         return Err(StepError::E3003_CANT_GET_VERSION);
     };
 
-    let Ok(latest_version) = get_latest_version(&version_data) else {
-        return Err(StepError::E3003_CANT_GET_VERSION);
-    };
+    let latest_version = get_latest_version(&version_data)?;
 
     let Ok(()) = fs::rename(
         explorer_path().join(latest_version),

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -483,9 +483,9 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         .map_err(|source| DCLError::E3007_VERSION_DATA_WRITE_FAILED { source })?;
 
     // Remove the downloaded file
-    fs::remove_file(&file_path).map_err(|e| DCLError::E1006_FILE_DELETE_FAILED {
+    fs::remove_file(&file_path).map_err(|source| DCLError::E1006_FILE_DELETE_FAILED {
         file_path: file_path.to_string_lossy().into_owned(),
-        inner_error: e.into(),
+        source,
     })?;
     cleanup_versions(&current_version)?;
 

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -301,7 +301,7 @@ fn cleanup_versions(current_version: &EntryVersion) -> DCLErrorResult {
 
     let explorer_path = explorer_path();
     let entries =
-        fs::read_dir(&explorer_path).map_err(|e| as_stale_cleanup_err(&explorer_path, e))?;
+        fs::read_dir(&explorer_path).map_err(|e| DCLError::from_cleanup(&explorer_path, e))?;
 
     let mut installations: Vec<EntryVersion> = Vec::new();
 
@@ -309,7 +309,7 @@ fn cleanup_versions(current_version: &EntryVersion) -> DCLErrorResult {
         let Ok(entry) = entry else { continue };
         let file_name = entry.file_name();
         let entry_name = file_name.to_str().ok_or_else(|| {
-            as_stale_cleanup_err(
+            DCLError::from_cleanup(
                 &entry.path(),
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -387,47 +387,18 @@ pub fn target_download_path() -> PathBuf {
     explorer_downloads_path().join(EXPLORER_DOWNLOADED_FILENAME)
 }
 
-fn as_rename_back_err(path: &Path, source: std::io::Error) -> DCLError {
-    DCLError::E3006_RENAME_BACK_FAILED {
-        path: path.to_string_lossy().into_owned(),
-        source,
-    }
-}
-
-fn as_stale_cleanup_err(path: &Path, source: std::io::Error) -> DCLError {
-    DCLError::E3005_STALE_BUILD_CLEANUP_FAILED {
-        path: path.to_string_lossy().into_owned(),
-        source,
-    }
-}
-
-fn as_launch_failed_err(path: &Path, inner_error: anyhow::Error) -> DCLError {
-    DCLError::E3010_EXPLORER_LAUNCH_FAILED {
-        path: path.to_string_lossy().into_owned(),
-        inner_error,
-    }
-}
-
-#[cfg(windows)]
-fn as_binary_access_err(path: &Path, source: std::io::Error) -> DCLError {
-    DCLError::E3013_EXPLORER_BINARY_ACCESS_FAILED {
-        path: path.to_string_lossy().into_owned(),
-        source,
-    }
-}
-
 fn rename_latest_back_to_version(
     latest_path: &Path,
     target: &Path,
     branch_path: &Path,
 ) -> DCLErrorResult {
     if target == branch_path {
-        return fs::remove_dir_all(latest_path).map_err(|e| as_rename_back_err(latest_path, e));
+        return fs::remove_dir_all(latest_path).map_err(|e| DCLError::from_rename_back(latest_path, e));
     }
     if target.exists() {
-        fs::remove_dir_all(target).map_err(|e| as_rename_back_err(target, e))?;
+        fs::remove_dir_all(target).map_err(|e| DCLError::from_rename_back(target, e))?;
     }
-    fs::rename(latest_path, target).map_err(|e| as_rename_back_err(latest_path, e))
+    fs::rename(latest_path, target).map_err(|e| DCLError::from_rename_back(latest_path, e))
 }
 
 pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) -> DCLErrorResult {
@@ -666,7 +637,7 @@ impl InstallsHub {
         // the permissions issue
         #[cfg(windows)]
         fs::metadata(&explorer_launch_path)
-            .map_err(|e| as_binary_access_err(&explorer_launch_path, e))?;
+            .map_err(|e| DCLError::from_binary_access(&explorer_launch_path, e))?;
 
         // Prepare explorer parameters
         #[cfg(target_os = "macos")]
@@ -690,13 +661,13 @@ impl InstallsHub {
 
             macos_params.append(&mut explorer_params);
             Self::launch_open_blocking(explorer_launch_dir, &macos_params)
-                .map_err(|e| as_launch_failed_err(&explorer_launch_path, e))?;
+                .map_err(|e| DCLError::from_launch_failure(&explorer_launch_path, e))?;
         }
 
         #[cfg(target_os = "windows")]
         let mut child =
             Self::launch_command(&explorer_launch_path, explorer_launch_dir, &explorer_params)
-                .map_err(|e| as_launch_failed_err(&explorer_launch_path, e))?;
+                .map_err(|e| DCLError::from_launch_failure(&explorer_launch_path, e))?;
 
         #[cfg(target_os = "windows")]
         {

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -487,9 +487,8 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         file_path: file_path.to_string_lossy().into_owned(),
         source,
     })?;
-    cleanup_versions(&current_version)?;
-
-    Ok(())
+    
+    cleanup_versions(&current_version)
 }
 
 pub fn rename_explorer_to_latest() -> DCLErrorResult {

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -384,6 +384,21 @@ fn as_rename_back_err(path: &Path, source: std::io::Error) -> StepError {
     }
 }
 
+fn as_launch_failed_err(path: &Path, inner_error: anyhow::Error) -> StepError {
+    StepError::E3010_EXPLORER_LAUNCH_FAILED {
+        path: path.to_string_lossy().into_owned(),
+        inner_error,
+    }
+}
+
+#[cfg(windows)]
+fn as_binary_access_err(path: &Path, source: std::io::Error) -> StepError {
+    StepError::E3013_EXPLORER_BINARY_ACCESS_FAILED {
+        path: path.to_string_lossy().into_owned(),
+        source,
+    }
+}
+
 fn rename_latest_back_to_version(
     latest_path: &Path,
     target: &Path,
@@ -579,7 +594,7 @@ impl InstallsHub {
         &self,
         deeplink: Option<DeepLink>,
         preferred_version: Option<&str>,
-    ) -> Result<()> {
+    ) -> StepResult {
         let readable_version = Self::readable_version(preferred_version);
 
         self.send_analytics_event(Event::LAUNCH_CLIENT_START {
@@ -592,7 +607,7 @@ impl InstallsHub {
         if let Err(e) = &result {
             self.send_analytics_event(Event::LAUNCH_CLIENT_ERROR {
                 version: readable_version,
-                error: e.to_string(),
+                error: format!("{:?}", e),
             })
             .await;
         } else {
@@ -612,7 +627,7 @@ impl InstallsHub {
         &self,
         deeplink: Option<DeepLink>,
         preferred_version: Option<&str>,
-    ) -> Result<()> {
+    ) -> StepResult {
         log::info!("Launching Explorer...");
 
         // macOS uses .app instaed of launching direct binary
@@ -623,18 +638,17 @@ impl InstallsHub {
             .ok_or_else(|| anyhow!("Failed to get explorer binary directory"))?;
 
         if !explorer_launch_path.exists() {
-            let error_message = match preferred_version {
-                Some(ver) => format!("The explorer version specified ({}) is not installed.", ver),
-                None => "The explorer is not installed.".to_string(),
-            };
-            log::error!("{}, {}", error_message, explorer_launch_path.display());
-            return Err(anyhow!(error_message));
+            return Err(StepError::E3009_EXPLORER_NOT_INSTALLED {
+                expected_path: explorer_launch_path.to_string_lossy().into_owned(),
+                version: preferred_version.map(str::to_owned),
+            });
         }
 
         // Ensure binary is executable, windows only, macOS doesn't use direct launch due
         // the permissions issue
         #[cfg(windows)]
-        fs::metadata(&explorer_launch_path).context("Failed to access explorer binary")?;
+        fs::metadata(&explorer_launch_path)
+            .map_err(|e| as_binary_access_err(&explorer_launch_path, e))?;
 
         // Prepare explorer parameters
         #[cfg(target_os = "macos")]
@@ -657,12 +671,14 @@ impl InstallsHub {
             ];
 
             macos_params.append(&mut explorer_params);
-            Self::launch_open_blocking(explorer_launch_dir, &macos_params)?;
+            Self::launch_open_blocking(explorer_launch_dir, &macos_params)
+                .map_err(|e| as_launch_failed_err(&explorer_launch_path, e))?;
         }
 
         #[cfg(target_os = "windows")]
         let mut child =
-            Self::launch_command(&explorer_launch_path, explorer_launch_dir, &explorer_params)?;
+            Self::launch_command(&explorer_launch_path, explorer_launch_dir, &explorer_params)
+                .map_err(|e| as_launch_failed_err(&explorer_launch_path, e))?;
 
         #[cfg(target_os = "windows")]
         {
@@ -685,10 +701,9 @@ impl InstallsHub {
             };
 
             if tokio::time::timeout(POLL_TIMEOUT, poll).await.is_err() {
-                return Err(anyhow!(
-                    "Explorer process under {} did not start",
-                    explorer_launch_path.display()
-                ));
+                return Err(StepError::E3011_EXPLORER_PROCESS_NOT_STARTED {
+                    path: explorer_launch_path.to_string_lossy().into_owned(),
+                });
             }
         }
 
@@ -713,10 +728,9 @@ impl InstallsHub {
                         break;
                     }
 
-                    return Err(anyhow!(
-                        "Child process died shorly after launch with code: {}",
-                        exit_status
-                    ));
+                    return Err(StepError::E3012_EXPLORER_EXITED_ON_LAUNCH {
+                        exit_code: exit_status.to_string(),
+                    });
                 }
 
                 thread::sleep(CHECK_INTERVAL);

--- a/core/src/installs.rs
+++ b/core/src/installs.rs
@@ -3,7 +3,7 @@ use crate::analytics::event::Event;
 use crate::config;
 use crate::download_origin_metadata::startup_location_storage::StartupDeeplinkStorage;
 use crate::environment::AppEnvironment;
-use crate::errors::{StepError, StepResult, StepResultTyped};
+use crate::errors::{DCLError, DCLErrorResult, DCLErrorTyped};
 use crate::instances::RunningInstances;
 #[cfg(target_os = "windows")]
 use crate::processes::CommandExtDetached;
@@ -165,14 +165,14 @@ fn get_version_data_or_empty() -> Map<String, Value> {
     })
 }
 
-fn get_latest_version(version_data: &Map<String, Value>) -> StepResultTyped<&str> {
+fn get_latest_version(version_data: &Map<String, Value>) -> DCLErrorTyped<&str> {
     version_data
         .get("version")
         .and_then(|v| v.as_str())
-        .ok_or(StepError::E3003_CANT_GET_VERSION)
+        .ok_or(DCLError::E3003_CANT_GET_VERSION)
 }
 
-pub(crate) fn get_explorer_launch_path(version: Option<&str>) -> StepResultTyped<PathBuf> {
+pub(crate) fn get_explorer_launch_path(version: Option<&str>) -> DCLErrorTyped<PathBuf> {
     let base_path = match version {
         None => explorer_latest_version_path(),
         Some("dev") => explorer_dev_version_path(),
@@ -296,7 +296,7 @@ fn remove_version_if_exists(version: &EntryVersion) {
     }
 }
 
-fn cleanup_versions(current_version: &EntryVersion) -> StepResult {
+fn cleanup_versions(current_version: &EntryVersion) -> DCLErrorResult {
     const KEEP_VERSIONS_FOR_ROLLBACK_AMOUNT: usize = 2;
 
     let explorer_path = explorer_path();
@@ -387,30 +387,30 @@ pub fn target_download_path() -> PathBuf {
     explorer_downloads_path().join(EXPLORER_DOWNLOADED_FILENAME)
 }
 
-fn as_rename_back_err(path: &Path, source: std::io::Error) -> StepError {
-    StepError::E3006_RENAME_BACK_FAILED {
+fn as_rename_back_err(path: &Path, source: std::io::Error) -> DCLError {
+    DCLError::E3006_RENAME_BACK_FAILED {
         path: path.to_string_lossy().into_owned(),
         source,
     }
 }
 
-fn as_stale_cleanup_err(path: &Path, source: std::io::Error) -> StepError {
-    StepError::E3005_STALE_BUILD_CLEANUP_FAILED {
+fn as_stale_cleanup_err(path: &Path, source: std::io::Error) -> DCLError {
+    DCLError::E3005_STALE_BUILD_CLEANUP_FAILED {
         path: path.to_string_lossy().into_owned(),
         source,
     }
 }
 
-fn as_launch_failed_err(path: &Path, inner_error: anyhow::Error) -> StepError {
-    StepError::E3010_EXPLORER_LAUNCH_FAILED {
+fn as_launch_failed_err(path: &Path, inner_error: anyhow::Error) -> DCLError {
+    DCLError::E3010_EXPLORER_LAUNCH_FAILED {
         path: path.to_string_lossy().into_owned(),
         inner_error,
     }
 }
 
 #[cfg(windows)]
-fn as_binary_access_err(path: &Path, source: std::io::Error) -> StepError {
-    StepError::E3013_EXPLORER_BINARY_ACCESS_FAILED {
+fn as_binary_access_err(path: &Path, source: std::io::Error) -> DCLError {
+    DCLError::E3013_EXPLORER_BINARY_ACCESS_FAILED {
         path: path.to_string_lossy().into_owned(),
         source,
     }
@@ -420,7 +420,7 @@ fn rename_latest_back_to_version(
     latest_path: &Path,
     target: &Path,
     branch_path: &Path,
-) -> StepResult {
+) -> DCLErrorResult {
     if target == branch_path {
         return fs::remove_dir_all(latest_path).map_err(|e| as_rename_back_err(latest_path, e));
     }
@@ -430,7 +430,7 @@ fn rename_latest_back_to_version(
     fs::rename(latest_path, target).map_err(|e| as_rename_back_err(latest_path, e))
 }
 
-pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) -> StepResult {
+pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) -> DCLErrorResult {
     let current_version: EntryVersion = EntryVersion::from_str(version)
         .ok_or_else(|| anyhow!("Version value cannot be parsed: {version}"))?;
 
@@ -439,7 +439,7 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
     let file_path = downloaded_file_path.unwrap_or_else(target_download_path);
 
     if !file_path.exists() {
-        return StepError::E1001_FILE_NOT_FOUND {
+        return DCLError::E1001_FILE_NOT_FOUND {
             expected_path: Some(file_path.to_string_lossy().into_owned()),
         }
         .into();
@@ -447,7 +447,7 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
 
     if branch_path.exists() {
         fs::remove_dir_all(&branch_path).map_err(|source| {
-            StepError::E3005_STALE_BUILD_CLEANUP_FAILED {
+            DCLError::E3005_STALE_BUILD_CLEANUP_FAILED {
                 path: branch_path.to_string_lossy().into_owned(),
                 source,
             }
@@ -509,10 +509,10 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
         serde_json::to_string(&version_data).context("Cannot serialize version_data")?;
     let version_path = explorer_version_path();
     fs::write(version_path, version_data_str)
-        .map_err(|source| StepError::E3007_VERSION_DATA_WRITE_FAILED { source })?;
+        .map_err(|source| DCLError::E3007_VERSION_DATA_WRITE_FAILED { source })?;
 
     // Remove the downloaded file
-    fs::remove_file(&file_path).map_err(|e| StepError::E1006_FILE_DELETE_FAILED {
+    fs::remove_file(&file_path).map_err(|e| DCLError::E1006_FILE_DELETE_FAILED {
         file_path: file_path.to_string_lossy().into_owned(),
         inner_error: e.into(),
     })?;
@@ -521,9 +521,9 @@ pub fn install_explorer(version: &str, downloaded_file_path: Option<PathBuf>) ->
     Ok(())
 }
 
-pub fn rename_explorer_to_latest() -> StepResult {
+pub fn rename_explorer_to_latest() -> DCLErrorResult {
     let Ok(version_data) = get_version_data() else {
-        return Err(StepError::E3003_CANT_GET_VERSION);
+        return Err(DCLError::E3003_CANT_GET_VERSION);
     };
 
     let latest_version = get_latest_version(&version_data)?;
@@ -532,7 +532,7 @@ pub fn rename_explorer_to_latest() -> StepResult {
         explorer_path().join(latest_version),
         explorer_latest_version_path(),
     ) else {
-        return Err(StepError::E3004_CANT_RENAME_LATEST);
+        return Err(DCLError::E3004_CANT_RENAME_LATEST);
     };
 
     Ok(())
@@ -612,7 +612,7 @@ impl InstallsHub {
         &self,
         deeplink: Option<DeepLink>,
         preferred_version: Option<&str>,
-    ) -> StepResult {
+    ) -> DCLErrorResult {
         let readable_version = Self::readable_version(preferred_version);
 
         self.send_analytics_event(Event::LAUNCH_CLIENT_START {
@@ -645,7 +645,7 @@ impl InstallsHub {
         &self,
         deeplink: Option<DeepLink>,
         preferred_version: Option<&str>,
-    ) -> StepResult {
+    ) -> DCLErrorResult {
         log::info!("Launching Explorer...");
 
         // macOS uses .app instaed of launching direct binary
@@ -656,7 +656,7 @@ impl InstallsHub {
             .ok_or_else(|| anyhow!("Failed to get explorer binary directory"))?;
 
         if !explorer_launch_path.exists() {
-            return Err(StepError::E3009_EXPLORER_NOT_INSTALLED {
+            return Err(DCLError::E3009_EXPLORER_NOT_INSTALLED {
                 expected_path: explorer_launch_path.to_string_lossy().into_owned(),
                 version: preferred_version.map(str::to_owned),
             });
@@ -719,7 +719,7 @@ impl InstallsHub {
             };
 
             if tokio::time::timeout(POLL_TIMEOUT, poll).await.is_err() {
-                return Err(StepError::E3011_EXPLORER_PROCESS_NOT_STARTED {
+                return Err(DCLError::E3011_EXPLORER_PROCESS_NOT_STARTED {
                     path: explorer_launch_path.to_string_lossy().into_owned(),
                 });
             }
@@ -746,7 +746,7 @@ impl InstallsHub {
                         break;
                     }
 
-                    return Err(StepError::E3012_EXPLORER_EXITED_ON_LAUNCH {
+                    return Err(DCLError::E3012_EXPLORER_EXITED_ON_LAUNCH {
                         exit_code: exit_status.to_string(),
                     });
                 }

--- a/core/src/installs/compression.rs
+++ b/core/src/installs/compression.rs
@@ -1,4 +1,4 @@
-use crate::errors::{StepError, StepResult};
+use crate::errors::{DCLError, DCLErrorResult};
 use std::{
     fs,
     io::{Cursor, Read, Write},
@@ -7,9 +7,9 @@ use std::{
 use tar::Archive;
 use zip::read::ZipArchive;
 
-pub fn decompress_file(source_path: &PathBuf, destination_path: &PathBuf) -> StepResult {
+pub fn decompress_file(source_path: &PathBuf, destination_path: &PathBuf) -> DCLErrorResult {
     if !source_path.exists() {
-        return StepError::E1001_FILE_NOT_FOUND {
+        return DCLError::E1001_FILE_NOT_FOUND {
             expected_path: Some(source_path.to_string_lossy().into_owned()),
         }
         .into();

--- a/core/src/logs.rs
+++ b/core/src/logs.rs
@@ -3,6 +3,9 @@ use anyhow::Result;
 use log::{Metadata, Record, info};
 use sentry_log::SentryLogger;
 
+pub const LOG_TO_FILE: &str = "dest:file";
+pub const LOG_TO_SENTRY: &str = "dest:sentry";
+
 pub fn dispath_logs() -> Result<()> {
     let path = installs::log_file_path()?;
     let log_file = fern::log_file(&path)?;
@@ -16,7 +19,7 @@ pub fn dispath_logs() -> Result<()> {
                 "[{} {} {}] {}",
                 humantime::format_rfc3339(std::time::SystemTime::now()),
                 record.level(),
-                record.target(),
+                record.module_path().unwrap_or_else(|| record.target()),
                 message
             ));
         })
@@ -58,8 +61,14 @@ impl log::Log for CombinedLog {
     }
 
     fn log(&self, record: &Record) {
-        self.fern.log(record);
-        self.sentry.log(record);
+        match record.target() {
+            LOG_TO_FILE => self.fern.log(record),
+            LOG_TO_SENTRY => self.sentry.log(record),
+            _ => {
+                self.fern.log(record);
+                self.sentry.log(record);
+            }
+        }
     }
 
     fn flush(&self) {

--- a/core/src/logs.rs
+++ b/core/src/logs.rs
@@ -3,8 +3,37 @@ use anyhow::Result;
 use log::{Metadata, Record, info};
 use sentry_log::SentryLogger;
 
-pub const LOG_TO_FILE: &str = "dest:file";
-pub const LOG_TO_SENTRY: &str = "dest:sentry";
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LogDestination {
+    File,
+    Sentry,
+    All,
+}
+
+impl LogDestination {
+    const FILE_TARGET: &'static str = "dest:file";
+    const SENTRY_TARGET: &'static str = "dest:sentry";
+    const ALL_TARGET: &'static str = "dest:all";
+
+    #[must_use]
+    pub const fn as_target(self) -> &'static str {
+        match self {
+            Self::File => Self::FILE_TARGET,
+            Self::Sentry => Self::SENTRY_TARGET,
+            Self::All => Self::ALL_TARGET,
+        }
+    }
+}
+
+impl From<&str> for LogDestination {
+    fn from(target: &str) -> Self {
+        match target {
+            Self::FILE_TARGET => Self::File,
+            Self::SENTRY_TARGET => Self::Sentry,
+            _ => Self::All,
+        }
+    }
+}
 
 pub fn dispath_logs() -> Result<()> {
     let path = installs::log_file_path()?;
@@ -61,10 +90,10 @@ impl log::Log for CombinedLog {
     }
 
     fn log(&self, record: &Record) {
-        match record.target() {
-            LOG_TO_FILE => self.fern.log(record),
-            LOG_TO_SENTRY => self.sentry.log(record),
-            _ => {
+        match LogDestination::from(record.target()) {
+            LogDestination::File => self.fern.log(record),
+            LogDestination::Sentry => self.sentry.log(record),
+            LogDestination::All => {
                 self.fern.log(record);
                 self.sentry.log(record);
             }

--- a/core/src/s3.rs
+++ b/core/src/s3.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::environment::{AppEnvironment, Args};
-use crate::errors::{StepError, StepResultTyped};
+use crate::errors::{DCLError, DCLErrorTyped};
 use crate::utils::get_os_name;
 
 pub const RELEASE_PREFIX: &str = "@dcl/unity-explorer/releases";
@@ -36,7 +36,7 @@ fn latest_json_url() -> String {
     )
 }
 
-async fn fetch_explorer_latest_release() -> StepResultTyped<LatestRelease> {
+async fn fetch_explorer_latest_release() -> DCLErrorTyped<LatestRelease> {
     let url = latest_json_url();
     log::info!(
         "[fetch_explorer_latest_release] Fetching latest release from: {}",
@@ -46,7 +46,7 @@ async fn fetch_explorer_latest_release() -> StepResultTyped<LatestRelease> {
     let response = reqwest::get(&url).await?;
 
     if !response.status().is_success() {
-        return StepError::E2004_DOWNLOAD_FAILED_HTTP_CODE {
+        return DCLError::E2004_DOWNLOAD_FAILED_HTTP_CODE {
             url,
             code: response.status().into(),
         }
@@ -62,7 +62,7 @@ async fn fetch_explorer_latest_release() -> StepResultTyped<LatestRelease> {
     Ok(data)
 }
 
-pub async fn get_latest_explorer_release() -> StepResultTyped<ReleaseResponse> {
+pub async fn get_latest_explorer_release() -> DCLErrorTyped<ReleaseResponse> {
     let url = AppEnvironment::bucket_url();
     let latest_release = fetch_explorer_latest_release().await?;
     let os = get_os_name();


### PR DESCRIPTION
## What

- Errors are grouped in Sentry by a stable error code (tag + fingerprint), so occurrences of the same failure land in one issue instead of splitting by message.
- Errors are reported once: logs can now target a destination (file / Sentry / both), so errors captured explicitly aren't duplicated by the log bridge.
- The launch path returns typed errors with their own codes instead of generic `anyhow` errors, so each launch failure mode is pivotable on its own in Sentry and gets its own user-facing message.
- `StepError` renamed to `DCLError` — it's no longer step-specific — and error construction moved onto the type itself instead of per-module helpers.

## Test instructions

Just run the launcher normally, check everything is OK