### PR TITLE
fix: VCRUNTIME140.dll not found on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,28 +280,6 @@ jobs:
           args: ${{ matrix.args }}
           projectPath: ${{ env.PROJECT_PATH }}
 
-      - name: Verify static CRT (Win)
-        if: ${{ matrix.os == 'windows-latest' }}
-        shell: pwsh
-        run: |
-          $exes = @(
-            "${{ github.workspace }}\src-tauri\target\release\dcl_launcher.exe",
-            "${{ github.workspace }}\src-tauri\resources\auto-auth-token-fetch.exe"
-          )
-          $failed = $false
-          foreach ($exe in $exes) {
-            if (-not (Test-Path $exe)) { throw "missing binary: $exe" }
-            $text = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($exe))
-            $hits = @('VCRUNTIME140', 'MSVCP140') | Where-Object { $text -match $_ }
-            if ($hits) {
-              Write-Host "::error::$exe imports $($hits -join ', ') - static CRT did not apply"
-              $failed = $true
-            } else {
-              Write-Host "$exe OK (static CRT)"
-            }
-          }
-          if ($failed) { exit 1 }
-
       - name: Sign dcl_launcher.exe manually (Win)
         if: ${{ matrix.os == 'windows-latest' }}
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,17 @@ jobs:
           cache-targets: true
           cache-provider: github
 
+      # The cache restores src-tauri/target, which carries bundle and installer
+      # staging output from earlier runs. Those copies can end up inside the
+      # installer instead of the ones this run builds, so drop them first.
+      - name: Purge cached bundle output
+        run: |
+          rm -rf src-tauri/target/release/bundle \
+                 src-tauri/target/release/nsis \
+                 src-tauri/target/universal-apple-darwin/release/bundle
+          find src-tauri/target -name 'auto-auth-token-fetch.exe' -delete || true
+          find src-tauri/target -name 'Decentraland_*setup.exe' -delete || true
+
       - uses: actions/setup-node@v5
         with:
           node-version: lts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,13 +120,16 @@ jobs:
           cache-targets: true
           cache-provider: github
 
-      # The cache restores src-tauri/target, which carries bundle and installer
-      # staging output from earlier runs. Those copies can end up inside the
-      # installer instead of the ones this run builds, so drop them first.
+      # The cache restores src-tauri/target, which carries binaries and bundle
+      # staging output from earlier runs. Those copies can be the ones packaged
+      # into the installer, so drop them before building.
       - name: Purge cached bundle output
         run: |
+          echo "Stale copies found:"
+          find src-tauri/target -name 'auto-auth-token-fetch.exe' -printf '%p\t%TY-%Tm-%Td\n' || true
           rm -rf src-tauri/target/release/bundle \
                  src-tauri/target/release/nsis \
+                 src-tauri/target/release/resources \
                  src-tauri/target/universal-apple-darwin/release/bundle
           find src-tauri/target -name 'auto-auth-token-fetch.exe' -delete || true
           find src-tauri/target -name 'Decentraland_*setup.exe' -delete || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,28 @@ jobs:
           args: ${{ matrix.args }}
           projectPath: ${{ env.PROJECT_PATH }}
 
+      - name: Verify static CRT (Win)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          $exes = @(
+            "${{ github.workspace }}\src-tauri\target\release\dcl_launcher.exe",
+            "${{ github.workspace }}\src-tauri\resources\auto-auth-token-fetch.exe"
+          )
+          $failed = $false
+          foreach ($exe in $exes) {
+            if (-not (Test-Path $exe)) { throw "missing binary: $exe" }
+            $text = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($exe))
+            $hits = @('VCRUNTIME140', 'MSVCP140') | Where-Object { $text -match $_ }
+            if ($hits) {
+              Write-Host "::error::$exe imports $($hits -join ', ') - static CRT did not apply"
+              $failed = $true
+            } else {
+              Write-Host "$exe OK (static CRT)"
+            }
+          }
+          if ($failed) { exit 1 }
+
       - name: Sign dcl_launcher.exe manually (Win)
         if: ${{ matrix.os == 'windows-latest' }}
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,20 +120,6 @@ jobs:
           cache-targets: true
           cache-provider: github
 
-      # The cache restores src-tauri/target, which carries binaries and bundle
-      # staging output from earlier runs. Those copies can be the ones packaged
-      # into the installer, so drop them before building.
-      - name: Purge cached bundle output
-        run: |
-          echo "Stale copies found:"
-          find src-tauri/target -name 'auto-auth-token-fetch.exe' -printf '%p\t%TY-%Tm-%Td\n' || true
-          rm -rf src-tauri/target/release/bundle \
-                 src-tauri/target/release/nsis \
-                 src-tauri/target/release/resources \
-                 src-tauri/target/universal-apple-darwin/release/bundle
-          find src-tauri/target -name 'auto-auth-token-fetch.exe' -delete || true
-          find src-tauri/target -name 'Decentraland_*setup.exe' -delete || true
-
       - uses: actions/setup-node@v5
         with:
           node-version: lts/*

--- a/core/.cargo/config.toml
+++ b/core/.cargo/config.toml
@@ -3,3 +3,19 @@ rustflags = [
   "-Dwarnings",         # treat all warnings as errors
   "-Dunsafe_code",      # deny unsafe blocks globally
 ]
+
+# Cargo uses a single rustflags source: these target sections replace [build]
+# rather than adding to it, so the lint denials are repeated here.
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+  "-Dwarnings",
+  "-Dunsafe_code",
+  "-C", "target-feature=+crt-static",   # no vcruntime140.dll dependency
+]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = [
+  "-Dwarnings",
+  "-Dunsafe_code",
+  "-C", "target-feature=+crt-static",
+]

--- a/src-auto-auth/.cargo/config.toml
+++ b/src-auto-auth/.cargo/config.toml
@@ -3,3 +3,19 @@ rustflags = [
   "-Dwarnings",         # treat all warnings as errors
   "-Dunsafe_code",      # deny unsafe blocks globally
 ]
+
+# Cargo uses a single rustflags source: these target sections replace [build]
+# rather than adding to it, so the lint denials are repeated here.
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+  "-Dwarnings",
+  "-Dunsafe_code",
+  "-C", "target-feature=+crt-static",   # no vcruntime140.dll dependency
+]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = [
+  "-Dwarnings",
+  "-Dunsafe_code",
+  "-C", "target-feature=+crt-static",
+]

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -3,3 +3,19 @@ rustflags = [
   "-Dwarnings",         # treat all warnings as errors
   "-Dunsafe_code",      # deny unsafe blocks globally
 ]
+
+# Cargo uses a single rustflags source: these target sections replace [build]
+# rather than adding to it, so the lint denials are repeated here.
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+  "-Dwarnings",
+  "-Dunsafe_code",
+  "-C", "target-feature=+crt-static",   # no vcruntime140.dll dependency
+]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = [
+  "-Dwarnings",
+  "-Dunsafe_code",
+  "-C", "target-feature=+crt-static",
+]


### PR DESCRIPTION
## Problem

On a clean Windows install, the installer fails with:

> The code execution cannot proceed because VCRUNTIME140.dll was not found.

That DLL comes from Microsoft's Visual C++ Redistributable. Windows doesn't include it out of the box, so machines that never installed it (directly, or through some other app) can't run our binaries. Most computers happen to have it, which is why this only shows up on a fresh machine or a clean VM.

The installer already had a step meant to install the redistributable, but its check never triggers on a machine that has never had it, so the download is skipped.

<img width="785" height="590" alt="Screenshot 2026-08-04 112640" src="https://github.com/user-attachments/assets/ec60ce96-374f-4d1d-80d2-9b817ce12bfb" />

## Fix

Build the Windows binaries with the C runtime bundled inside them instead of loading it from the system. No external DLL, nothing to install, nothing to download during setup.

## Testing

1. Install on a clean Windows 11 VM with no Visual C++ Redistributable — no DLL error
2. Before finishing the installation and running the explorer please make sure you have the .config file with `"cmd-arguments": "--never-trigger-updater"`
- Run the launcher after installation
- Everything should go normally until explorer opens

## Note

Binaries grow by a few hundred KB, and the first CI run recompiles everything from scratch.
