### PR TITLE
fix: vcruntime dynamic installation

### DIFF
--- a/src-tauri/windows/hooks.nsh
+++ b/src-tauri/windows/hooks.nsh
@@ -1,12 +1,30 @@
 !macro NSIS_HOOK_POSTINSTALL
-  ReadRegDWord $0 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Installed"
-  ${If} $0 == 0
-    nsExec::ExecToLog 'powershell -WindowStyle Hidden -Command "& { \
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-      Invoke-WebRequest -Uri \"https://aka.ms/vc14/vc_redist.x64.exe\" -OutFile \"$TEMP\vc_redist.x64.exe\"; \
-    }"'
-    nsExec::ExecToLog '"$TEMP\vc_redist.x64.exe" /quiet /norestart'
-    Delete "$TEMP\vc_redist.x64.exe"
+  ; A missing key leaves the output empty rather than 0, and a 32-bit installer
+  ; reads the WOW6432Node view, so require an explicit 1 in either view.
+  SetRegView 64
+  ReadRegDWord $0 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64" "Installed"
+  SetRegView 32
+  ReadRegDWord $3 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64" "Installed"
+  SetRegView lastused
+
+  ${If} $0 != 1
+  ${AndIf} $3 != 1
+    DetailPrint "Installing the Visual C++ redistributable"
+    nsExec::ExecToLog "powershell -NoProfile -WindowStyle Hidden -Command $\"[Net.ServicePointManager]::SecurityProtocol = 3072; Invoke-WebRequest -Uri https://aka.ms/vc14/vc_redist.x64.exe -OutFile '$TEMP\vc_redist.x64.exe'$\""
+    Pop $1
+    ${If} $1 == 0
+      nsExec::ExecToLog '"$TEMP\vc_redist.x64.exe" /quiet /norestart'
+      Pop $2
+      Delete "$TEMP\vc_redist.x64.exe"
+      ; 3010 means it installed and wants a reboot
+      ${If} $2 != 0
+      ${AndIf} $2 != 3010
+        DetailPrint "Visual C++ redistributable install failed with exit code $2"
+      ${EndIf}
+    ${Else}
+      DetailPrint "Could not download the Visual C++ redistributable (exit code $1)"
+    ${EndIf}
   ${EndIf}
+
   Exec '"$INSTDIR\resources\auto-auth-token-fetch.exe" "$EXEPATH"'
 !macroend


### PR DESCRIPTION
## Problem

The installer has a step that installs Microsoft's Visual C++ Redistributable when the machine doesn't have it. It never runs.

The check looks for a registry value and installs when that value says "not installed". But on a machine that never had the redistributable, the value doesn't exist at all — which is not the same as saying "not installed", so the step is skipped. It only ever triggers in a case that basically never happens in practice.

Result: the machines that need the redistributable are exactly the ones that don't get it.

The launcher itself no longer cares (#325 bundles the runtime into our binaries), but the Explorer is a Unity build that does need it.

## Fix

- Install unless the registry explicitly says the redistributable is present.
- Check both registry views — the installer is 32-bit, so it was reading the wrong place on 64-bit Windows.
- Stop treating a failed download as success: the redistributable installer is only run if the download actually worked, and failures are written to the install log.
- Fix the quoting in the download command, which was malformed and would have failed on user folders containing spaces.

## Testing

- [ ] Install on a clean Windows 11 VM with no Visual C++ Redistributable
- [ ] Install log shows `Installing the Visual C++ redistributable` with no failure lines after it
- [ ] Explorer downloads and starts
- [ ] Installing on a machine that already has the redistributable skips the step