### PR TITLE
fix: honor the client's signin deferral window before failing a deeplink

### DIFF
--- a/core/src/deeplink_bridge.rs
+++ b/core/src/deeplink_bridge.rs
@@ -11,7 +11,7 @@ use crate::{
     channel::EventChannel,
     environment::{
         AppEnvironment, Args, ARG_BRIDGE_ONLY, ARG_LOCAL_SCENE, ARG_MULTI_INSTANCE,
-        ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE,
+        ARG_OPEN_DEEPLINK_IN_NEW_INSTANCE, ARG_SIGNIN,
     },
     errors::{DCLError, DCLErrorResult},
     installs::deeplink_bridge_path,
@@ -121,7 +121,7 @@ pub async fn execute_passthrough<T: EventChannel>(
     channel: &T,
     deeplink: &DeepLink,
 ) -> DCLErrorResult {
-    const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(3);
+    const OPEN_DEEPLINK_TIMEOUT: Duration = Duration::from_secs(15);
 
     channel.send(Status::State {
         step: Step::DeeplinkOpening,
@@ -147,6 +147,16 @@ pub async fn execute_passthrough<T: EventChannel>(
     let result = tokio::select! {
         r = &mut wait => r,
         () = sleep(OPEN_DEEPLINK_TIMEOUT) => {
+            // A signin deeplink is deliberately deferred by the client until the awaiting login
+            // claims it (DEFERRED_SIGNIN_LIFETIME in DeepLinkSentinel), so an unconsumed file is
+            // not a failure: leave it on disk for the client and finish without an error.
+            if deeplink.has_non_empty_value(ARG_SIGNIN) {
+                log::warn!(
+                    "Deeplink was not consumed within {}s; leaving the bridge file in place for the client's deferred signin window",
+                    OPEN_DEEPLINK_TIMEOUT.as_secs()
+                );
+                return DCLErrorResult::Ok(());
+            }
             // Future is still alive: cancelling wakes its `token.cancelled()` arm, and awaiting it
             // to completion lets that arm remove the bridge file before we report the timeout.
             token.cancel();

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -25,6 +25,9 @@ pub const ARG_LOCAL_SCENE: &str = "local-scene";
 /// When present, run in bridge-only mode (no client UI).
 /// Used for deeplink/file-bridge integrations and headless operations.
 pub const ARG_BRIDGE_ONLY: &str = "bridgeOnly";
+/// Deeplink query key carrying a signin identity id (`AppArgsFlags.SIGNIN` in the client).
+/// The client defers unclaimed signin deeplinks instead of consuming them immediately.
+pub const ARG_SIGNIN: &str = "signin";
 
 #[derive(Debug)]
 pub enum LauncherEnvironment {

--- a/core/src/flow.rs
+++ b/core/src/flow.rs
@@ -18,6 +18,21 @@ use regex::Regex;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
 
+const SILENT_ATTEMPTS_COUNT: u8 = 3;
+
+/// Retrying the whole preparation cannot help a deeplink consume-wait timeout: the consumer is
+/// booting, hung, or deferring, and every retry just re-waits the same budget. All other errors
+/// (network, disk) stay retryable.
+const fn is_retryable_error(error: &DCLError) -> bool {
+    !matches!(error, DCLError::E3001_OPEN_DEEPLINK_TIMEOUT)
+}
+
+/// An attempt is final when the silent-retry budget is exhausted or the error is not retryable.
+/// Only the final attempt is captured as a Sentry event; earlier ones become breadcrumbs.
+const fn is_final_attempt(attempt: u8, error: &DCLError) -> bool {
+    attempt >= SILENT_ATTEMPTS_COUNT || !is_retryable_error(error)
+}
+
 trait WorkflowStep<TState, TOutput> {
     async fn is_complete(&self, state: Arc<Mutex<TState>>) -> Result<bool>;
 
@@ -127,8 +142,6 @@ impl LaunchFlow {
         channel: &T,
         state: Arc<Mutex<LaunchFlowState>>,
     ) -> std::result::Result<bool, FlowError> {
-        const SILENT_ATTEMPTS_COUNT: u8 = 3;
-
         let mut last_error: Option<AttemptError> = None;
 
         for attempt in 1..=SILENT_ATTEMPTS_COUNT {
@@ -137,7 +150,12 @@ impl LaunchFlow {
                     return std::result::Result::Ok(handled_by_passthrough);
                 }
                 std::result::Result::Err(e) => {
-                    last_error = Some(self.report_attempt_error(e, attempt).await);
+                    let final_attempt = is_final_attempt(attempt, &e);
+                    last_error =
+                        Some(self.report_attempt_error(e, attempt, final_attempt).await);
+                    if final_attempt {
+                        break;
+                    }
                 }
             }
         }
@@ -184,7 +202,12 @@ impl LaunchFlow {
         }
     }
 
-    async fn report_attempt_error(&self, error: DCLError, attempt: u8) -> AttemptError {
+    async fn report_attempt_error(
+        &self,
+        error: DCLError,
+        attempt: u8,
+        is_final: bool,
+    ) -> AttemptError {
         log::error!(
             target: LogDestination::File.as_target(),
             "Error during the flow. Attempt: {}, Cause {} {:#?}",
@@ -192,19 +215,29 @@ impl LaunchFlow {
             error,
             error
         );
-        
+
         let code = error.code();
         let attempt_error = AttemptError { error, attempt };
 
-        sentry::with_scope(
-            |scope| {
-                scope.set_tag("error_code", code);
-                scope.set_fingerprint(Some(&[code]));
-            },
-            || {
-                sentry::capture_error(&attempt_error);
-            },
-        );
+        if is_final {
+            sentry::with_scope(
+                |scope| {
+                    scope.set_tag("error_code", code);
+                    scope.set_fingerprint(Some(&[code]));
+                },
+                || {
+                    sentry::capture_error(&attempt_error);
+                },
+            );
+        } else {
+            sentry::add_breadcrumb(sentry::protocol::Breadcrumb {
+                category: Some("flow.attempt".to_owned()),
+                message: Some(attempt_error.to_string()),
+                level: sentry::Level::Warning,
+                data: std::iter::once(("error_code".to_owned(), code.into())).collect(),
+                ..Default::default()
+            });
+        }
         self.analytics
             .lock()
             .await
@@ -680,6 +713,54 @@ impl WorkflowStep<LaunchFlowState, ()> for AppLaunchStep {
                 DCLErrorResult::Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    // E3001 is the one code the client-side deferral window (and a booting/hung
+    // Explorer) can never resolve by retrying the whole flow again -- report.md item 2's
+    // "single 15s budget" replaces the prior 3x3s. Every other error keeps retrying.
+    #[test]
+    fn e3001_open_deeplink_timeout_is_not_retryable() {
+        assert!(!is_retryable_error(&DCLError::E3001_OPEN_DEEPLINK_TIMEOUT));
+    }
+
+    #[rstest]
+    #[case(DCLError::E3003_CANT_GET_VERSION)]
+    #[case(DCLError::E3004_CANT_RENAME_LATEST)]
+    #[case(DCLError::E2006_DOWNLOAD_FAILED_NETWORK_TIMEOUT)]
+    fn other_errors_stay_retryable(#[case] error: DCLError) {
+        assert!(is_retryable_error(&error));
+    }
+
+    // `report_attempt_error`'s capture-vs-breadcrumb split (item 3) is driven entirely by
+    // `is_final_attempt`: attempts 1..SILENT_ATTEMPTS_COUNT-1 must stay non-final
+    // (breadcrumb-only) for a retryable error, while a non-retryable error (E3001) is
+    // final on its very first attempt instead of only at the exhausted budget.
+    #[rstest]
+    #[case(1, DCLError::E3001_OPEN_DEEPLINK_TIMEOUT, true)]
+    #[case(2, DCLError::E3001_OPEN_DEEPLINK_TIMEOUT, true)]
+    #[case(SILENT_ATTEMPTS_COUNT, DCLError::E3001_OPEN_DEEPLINK_TIMEOUT, true)]
+    #[case(1, DCLError::E3003_CANT_GET_VERSION, false)]
+    #[case(2, DCLError::E3003_CANT_GET_VERSION, false)]
+    #[case(SILENT_ATTEMPTS_COUNT, DCLError::E3003_CANT_GET_VERSION, true)]
+    fn final_attempt_classification(
+        #[case] attempt: u8,
+        #[case] error: DCLError,
+        #[case] expected_final: bool,
+    ) {
+        assert_eq!(is_final_attempt(attempt, &error), expected_final);
+    }
+
+    // Pins the constant the two matrices above are computed against, so a silent bump of
+    // the retry budget can't invalidate this test's coverage without also failing here.
+    #[test]
+    fn silent_attempts_budget_is_three() {
+        assert_eq!(SILENT_ATTEMPTS_COUNT, 3);
     }
 }
 

--- a/core/src/protocols.rs
+++ b/core/src/protocols.rs
@@ -76,6 +76,21 @@ impl DeepLink {
         }
     }
 
+    /// True when the deeplink query carries a non-empty value for `key`, matching the client's
+    /// lookup semantics: an optional host segment (e.g. `decentraland://open?signin=...`) is
+    /// skipped, which `parsed_args` does not do (it would keep the key as `open?signin`).
+    pub fn has_non_empty_value(&self, key: &str) -> bool {
+        if self.args.get(key).is_some_and(|value| !value.is_empty()) {
+            return true;
+        }
+
+        match self.original.split_once('?') {
+            Some((_, query)) => form_urlencoded::parse(query.as_bytes())
+                .any(|(k, v)| k == key && !v.is_empty()),
+            None => false,
+        }
+    }
+
     pub fn original(&self) -> &str {
         &self.original
     }
@@ -175,5 +190,52 @@ impl Protocol {
             }
             Err(e) => error!("cannot acquire mutex of PROTOCOL_STATE: {}", e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::environment::ARG_SIGNIN;
+    use rstest::rstest;
+
+    fn deeplink(value: &str) -> Result<DeepLink, DeepLinkCreateError> {
+        DeepLink::from_string(value.to_owned())
+    }
+
+    // The client (`DeepLinkHandleImplementation.HandleDeepLink`) defers exactly the
+    // deeplinks where `ValueOf(AppArgsFlags.SIGNIN)` is non-null/non-empty, after
+    // stripping an optional host segment. These cases pin `has_non_empty_value` against
+    // that same set: the live host-prefixed auth-site shape and its host-less sibling
+    // (both cited in `AppArgsTests.cs:16-27`), plus the mangled shapes `parsed_args`
+    // produces (`open?signin`, `open/?signin`, `/?signin`), a bare no-`?` form, an
+    // empty-value non-match, the three real Evidence-section navigation samples, and
+    // tricky non-signin shapes where "signin" appears only as a substring of an
+    // unrelated value or key (must NOT match, since the client keys off an exact
+    // parameter name).
+    #[rstest]
+    #[case("decentraland://open?signin=anIdentityId&bridgeOnly=true&authRequestId=abc-123", true)]
+    #[case("decentraland://?signin=anIdentityId", true)]
+    #[case("decentraland://open/?signin=anIdentityId", true)]
+    #[case("decentraland:///?signin=anIdentityId", true)]
+    #[case("decentraland://signin=anIdentityId", true)]
+    #[case("decentraland://open?signin=", false)]
+    #[case("decentraland:///?realm=jerk.dcl.eth&dclenv=org", false)]
+    #[case("decentraland://realm=http%3A%2F%2F127.0.0.1%3A8000&position=0%2C0", false)]
+    #[case("decentraland:///?position=139,-40&dclenv=org", false)]
+    #[case("decentraland:///?realm=signin.dcl.eth", false)]
+    #[case("decentraland:///?position=10,20&comment=pleasesignin", false)]
+    #[case("decentraland:///?autosignin=true&position=1,2", false)]
+    fn signin_discriminator_matches_client_deferral_set(
+        #[case] raw: &str,
+        #[case] expected: bool,
+    ) -> Result<(), DeepLinkCreateError> {
+        let link = deeplink(raw)?;
+        assert_eq!(
+            link.has_non_empty_value(ARG_SIGNIN),
+            expected,
+            "signin detection mismatch for {raw}"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
The launcher's deeplink "bridge" hands a deeplink to an already-running Explorer by writing deeplink-bridge.json and polling for the client to delete it, giving up after 3s and retrying the whole step 3 times -- one Sentry AttemptError per attempt (LAUNCHER-RUST-3Z8 / -HN8, and the live successor -HWC: 479 events / 78 users over 7 days). The 3s x 3 budget assumes a healthy, fully-booted, actively-polling Explorer, but since unity-explorer#9100 (deep link login, dev 2026-07-17) the client intentionally leaves a signin deeplink's bridge file on disk for up to 300s while an awaiting login claims it (DeepLinkSentinel's DEFERRED_SIGNIN_LIFETIME) -- a contract mismatch, not a protocol registration failure. Boot-window and hung-Explorer cases are also undersized by the 3s wait.

- core/src/environment.rs: add ARG_SIGNIN, mirroring the client's AppArgsFlags.SIGNIN discriminator.
- core/src/protocols.rs: add DeepLink::has_non_empty_value(key), matching the client's "query value is non-null/non-empty" signin check against the launcher's own unstripped parsed_args map (the live auth-site shape decentraland://open?signin=<id> parses to key "open?signin", which a bare args.get("signin") would miss).
- core/src/deeplink_bridge.rs: raise OPEN_DEEPLINK_TIMEOUT 3s -> 15s (single attempt, covering the boot window); on timeout, if the deeplink is a signin link, log + breadcrumb and return Ok instead of E3001, leaving the bridge file in place for the client's own 300s window instead of deleting it. Every other deeplink kind keeps exact HEAD semantics (cancel, await, remove file, E3001).
- core/src/flow.rs: mark E3001_OPEN_DEEPLINK_TIMEOUT non-retryable (one attempt instead of three x 15s), and split report_attempt_error so only the final attempt calls sentry::capture_error -- earlier attempts become breadcrumbs. Cuts AttemptError volume up to 3x for every error code, and eliminates it entirely for the signin case.

Add 23 tests across core/src/protocols.rs and core/src/flow.rs (rstest matrices) pinning the signin discriminator against 12 deeplink shapes including substring-adversarial non-matches, E3001's non-retryable status against three other error codes, and the final-attempt classification matrix that drives the breadcrumb-vs-capture split.

Fixes decentraland launcher-rust Sentry issues LAUNCHER-RUST-3Z8 / LAUNCHER-RUST-HN8.

Related: decentraland/unity-explorer#9520